### PR TITLE
Force on-device speech recognition, error on cloud fallback

### DIFF
--- a/Vapor/Vapor/Services/SpeechDictationService.swift
+++ b/Vapor/Vapor/Services/SpeechDictationService.swift
@@ -157,10 +157,25 @@ final class SpeechDictationService {
                 return
             }
 
+            // Force on-device processing — never send audio to Apple servers.
+            // On Intel Macs or unsupported locales this will be false; we fail
+            // with a clear message rather than silently routing to the cloud.
+            guard #available(macOS 10.15, *), recognizer.supportsOnDeviceRecognition else {
+                logger.warning("On-device recognition not available for locale=\(recognizer.locale.identifier)")
+                self.state = .error("""
+                    On-device speech recognition is not available for your system or language.
+                    Supported: Apple Silicon with English, Spanish, French, German, Japanese, \
+                    or Chinese. Change your macOS language in System Settings, or wait for the \
+                    upcoming Whisper-based engine (see GitHub Issue #12).
+                    """)
+                return
+            }
+
             self.teardownAudioSession(preserveErrorState: true)
 
             let request = SFSpeechAudioBufferRecognitionRequest()
             request.shouldReportPartialResults = true
+            request.requiresOnDeviceRecognition = true
             self.recognitionRequest = request
 
             let inputNode = self.audioEngine.inputNode


### PR DESCRIPTION
## Summary

Hard-codes `SFSpeechRecognizer` to **only** use on-device recognition. If on-device is unavailable (Intel Mac, unsupported locale), the app now fails with a clear error message instead of silently routing audio to Apple's cloud servers.

## Changes

- `SpeechDictationService.swift`:
  - Added guard check: `recognizer.supportsOnDeviceRecognition`
  - Set `request.requiresOnDeviceRecognition = true` on all requests
  - Error message references Whisper migration plan (#12) so users know what's coming

## Why

The app's brand identity is privacy-first. The website and marketing claim on-device processing. Apple's framework defaults to cloud processing on Intel Macs and silently falls back to the cloud for unsupported languages/metadata. This patch eliminates that silent exfiltration path.

This is an interim fix — the long-term plan (issue #12) replaces Apple Speech entirely with **WhisperKit**, a fully local engine that only runs on Apple Silicon.

## Trade-off

Intel Mac users and users with unsupported locales will see an error instead of dictation working. This is intentional — we are officially dropping Intel support (see issue #12).

## Testing

- [ ] Verify dictation works on Apple Silicon (EN/ES/FR/DE/JA/ZH)
- [ ] Verify clear error appears on Intel Mac or unsupported locale
- [ ] No audio leaves the machine when error is shown

Closes prep work for #12