### PR TITLE
Add OpenCode session search indexing

### DIFF
--- a/.claude/skills/vapor-agent-memory/SKILL.md
+++ b/.claude/skills/vapor-agent-memory/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vapor-session-search
+name: vapor-agent-memory
 description: "Search Vapor's local indexed agent memory for the current session, including conversation turns and indexed tool/reasoning history."
 ---
 
@@ -31,8 +31,6 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   | python3 -m json.tool
 ```
 
-Response includes `session_id`, title, directory, and `index_status`.
-
 ## Check Index Status
 
 ```bash
@@ -50,17 +48,7 @@ Status values:
 - `missing`: session is not imported; ask the user to click **Import & Index** in Vapor.
 - `indexing`: indexing is running; try again shortly.
 
-Important fields:
-
-- `can_search`: true if search can be used.
-- `chunks`: number of indexed metadata chunks.
-- `vectors`: number of available searchable vectors.
-- `coverage`: `vectors / chunks`.
-- `message`: user-facing guidance.
-
 ## Search Agent Memory
-
-Current/inferred session:
 
 ```bash
 QUERY="dictation on local device vs cloud based"
@@ -77,13 +65,6 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   | python3 -m json.tool
 ```
 
-Legacy alias:
-
-```bash
-curl -s -H "Authorization: Bearer $TOKEN" \
-  "$BASE/api/session/search?q=sqlite%20vec%20filtering&session_id=ses_abc123&limit=10"
-```
-
 ## Interpret Results
 
 The score is cosine distance. Lower is better.
@@ -93,20 +74,11 @@ The score is cosine distance. Lower is better.
 - `< 0.60` is related.
 - Larger values are weaker.
 
-Results include:
-
-- `embedding_id`
-- `distance`
-- `chunk_text`
-- `turn_source_id`
-- `session_id`
-- `chunk_index`
-
 ## Expand Context
 
 ```bash
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "$BASE/api/session/ses_abc123/context?q=sqlite%20vec%20filtering&context_turns=2" \
+  "$BASE/api/agent/sessions/ses_abc123/context?q=sqlite%20vec%20filtering&context_turns=2" \
   | python3 -m json.tool
 ```
 

--- a/.claude/skills/vapor-session-search/SKILL.md
+++ b/.claude/skills/vapor-session-search/SKILL.md
@@ -1,110 +1,92 @@
 ---
 name: vapor-session-search
-description: "Search indexed OpenCode agent sessions via Vapor's local HTTP API. Supports semantic vector search across conversation turns and per-session context retrieval."
+description: "Search Vapor's local indexed agent memory for the current session, including conversation turns and indexed tool/reasoning history."
 ---
 
-# Vapor Session Search
+# Vapor Agent Memory Search
 
-Search indexed agent conversation sessions through Vapor's embedded HTTP API on `127.0.0.1:8766`.
+Use this skill when you need to recall prior decisions, errors, implementation details, tool results, or reasoning from the current indexed agent session.
 
-## Prerequisites
+Vapor exposes a local HTTP API on `http://127.0.0.1:8766`. Requests require `VAPOR_API_TOKEN` as a Bearer token.
 
-- Vapor must be running (macOS app with embedded HTTP server on port 8766)
-- Auth token available via `VAPOR_API_TOKEN` environment variable (auto-set by Vapor on launch)
-- Sessions must be indexed via "Import & Index" in the Vapor UI before they are searchable
+## Workflow
+
+1. Check index status before searching.
+2. Search only if `can_search` is `true`.
+3. If `can_search` is `false`, tell the user which Vapor UI action is needed.
+4. Use context expansion before relying on a result.
 
 ## Authentication
 
-All requests require a Bearer token. Use the `VAPOR_API_TOKEN` environment variable:
+```bash
+TOKEN="$VAPOR_API_TOKEN"
+BASE="${VAPOR_API_URL:-http://127.0.0.1:8766}"
+```
+
+## Check Current Session
 
 ```bash
-TOKEN=$VAPOR_API_TOKEN
-curl -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=..."
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/current-session?cwd=$(python3 -c 'import os,urllib.parse; print(urllib.parse.quote(os.getcwd()))')" \
+  | python3 -m json.tool
 ```
 
-## API Endpoints
-
-### Search Sessions
-
-Semantic vector search across indexed conversation turns.
+## Check Index Status
 
 ```bash
-TOKEN=$VAPOR_API_TOKEN
-
-# Search all indexed sessions
-curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=implement+authentication&limit=10" | python3 -m json.tool
-
-# Search within a specific session
-curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=error+handling&session_id=ses_abc123&limit=5" | python3 -m json.tool
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/index/status?session_id=ses_abc123" \
+  | python3 -m json.tool
 ```
 
-**Parameters:**
-- `q` (required): Search query text
-- `session_id` (optional): Scope search to a specific session
-- `limit` (optional, default 20): Max results to return
+Status values:
 
-**Response:**
-```json
-{
-  "results": [
-    {
-      "embedding_id": "turn:ses_abc123:msg_def456:0",
-      "distance": 0.42,
-      "chunk_text": "...relevant text from conversation...",
-      "turn_source_id": "msg_def456",
-      "session_id": "ses_abc123",
-      "chunk_index": 0
-    }
-  ],
-  "count": 1
-}
-```
+- `ready`: search is ready.
+- `dirty`: search is usable but session has newer data; ask the user to click **Update Search** in Vapor.
+- `partial`: search is usable but incomplete; ask the user to click **Update Search** if recall matters.
+- `repair_needed`: search is unavailable; ask the user to click **Repair Search** in Vapor.
+- `missing`: session is not imported; ask the user to click **Import & Index** in Vapor.
+- `indexing`: indexing is running; try again shortly.
 
-### Get Session Context
-
-Retrieve search results with full chunk context from surrounding turns.
+## Search Agent Memory
 
 ```bash
-TOKEN=$VAPOR_API_TOKEN
-
-curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/ses_abc123/context?q=authentication+flow&context_turns=2" | python3 -m json.tool
+QUERY="dictation on local device vs cloud based"
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/search?q=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))' "$QUERY")&limit=10" \
+  | python3 -m json.tool
 ```
 
-**Parameters:**
-- `session_id` (required, in URL path): Session to search
-- `q` (required): Search query
-- `context_turns` (optional, default 2): Number of surrounding turns to include
-- `limit` (optional, default 5): Max search results
-
-**Response:**
-```json
-{
-  "session_id": "ses_abc123",
-  "query": "authentication flow",
-  "results": [...],
-  "turn_chunks": [
-    {
-      "embedding_id": "turn:ses_abc123:msg_def456:0",
-      "chunk_text": "...full chunk text...",
-      "turn_source_id": "msg_def456",
-      "session_id": "ses_abc123",
-      "chunk_index": 0
-    }
-  ],
-  "unique_turns": ["msg_def456"]
-}
-```
-
-### Health Check
+Explicit session:
 
 ```bash
-curl -s "http://127.0.0.1:8766/api/status" | python3 -m json.tool
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/sessions/ses_abc123/search?q=sqlite%20vec%20filtering&limit=10" \
+  | python3 -m json.tool
 ```
 
-## Usage Tips
+## Interpret Results
 
-- Search queries work best with natural language descriptions of what you're looking for
-- The vector search uses MiniLM paraphrase-multilingual-L12-v2 embeddings (semantic similarity, not keyword matching)
-- Sessions must be manually indexed via "Import & Index" in Vapor's session window before they appear in search results
-- Each session's conversation is chunked into 512-character segments with 32-character overlap for granular matching
-- Only user and assistant text turns are indexed (tool calls, reasoning, patches are excluded)
+The score is cosine distance. Lower is better.
+
+- `0.0` is closest.
+- `< 0.30` is typically strong.
+- `< 0.60` is related.
+- Larger values are weaker.
+
+## Expand Context
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/session/ses_abc123/context?q=sqlite%20vec%20filtering&context_turns=2" \
+  | python3 -m json.tool
+```
+
+Use context expansion before making claims based on a search result.
+
+## Rules
+
+- Prefer current-session search unless the user asks for cross-session recall.
+- Always check status first if search quality matters.
+- If `can_search` is false, do not claim nothing was found; report the required Vapor action.
+- Do not trigger indexing from the API unless the user explicitly asks and the endpoint supports it.

--- a/.claude/skills/vapor-session-search/SKILL.md
+++ b/.claude/skills/vapor-session-search/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: vapor-session-search
+description: "Search indexed OpenCode agent sessions via Vapor's local HTTP API. Supports semantic vector search across conversation turns and per-session context retrieval."
+---
+
+# Vapor Session Search
+
+Search indexed agent conversation sessions through Vapor's embedded HTTP API on `127.0.0.1:8766`.
+
+## Prerequisites
+
+- Vapor must be running (macOS app with embedded HTTP server on port 8766)
+- Auth token available via `VAPOR_API_TOKEN` environment variable (auto-set by Vapor on launch)
+- Sessions must be indexed via "Import & Index" in the Vapor UI before they are searchable
+
+## Authentication
+
+All requests require a Bearer token. Use the `VAPOR_API_TOKEN` environment variable:
+
+```bash
+TOKEN=$VAPOR_API_TOKEN
+curl -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=..."
+```
+
+## API Endpoints
+
+### Search Sessions
+
+Semantic vector search across indexed conversation turns.
+
+```bash
+TOKEN=$VAPOR_API_TOKEN
+
+# Search all indexed sessions
+curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=implement+authentication&limit=10" | python3 -m json.tool
+
+# Search within a specific session
+curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=error+handling&session_id=ses_abc123&limit=5" | python3 -m json.tool
+```
+
+**Parameters:**
+- `q` (required): Search query text
+- `session_id` (optional): Scope search to a specific session
+- `limit` (optional, default 20): Max results to return
+
+**Response:**
+```json
+{
+  "results": [
+    {
+      "embedding_id": "turn:ses_abc123:msg_def456:0",
+      "distance": 0.42,
+      "chunk_text": "...relevant text from conversation...",
+      "turn_source_id": "msg_def456",
+      "session_id": "ses_abc123",
+      "chunk_index": 0
+    }
+  ],
+  "count": 1
+}
+```
+
+### Get Session Context
+
+Retrieve search results with full chunk context from surrounding turns.
+
+```bash
+TOKEN=$VAPOR_API_TOKEN
+
+curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/ses_abc123/context?q=authentication+flow&context_turns=2" | python3 -m json.tool
+```
+
+**Parameters:**
+- `session_id` (required, in URL path): Session to search
+- `q` (required): Search query
+- `context_turns` (optional, default 2): Number of surrounding turns to include
+- `limit` (optional, default 5): Max search results
+
+**Response:**
+```json
+{
+  "session_id": "ses_abc123",
+  "query": "authentication flow",
+  "results": [...],
+  "turn_chunks": [
+    {
+      "embedding_id": "turn:ses_abc123:msg_def456:0",
+      "chunk_text": "...full chunk text...",
+      "turn_source_id": "msg_def456",
+      "session_id": "ses_abc123",
+      "chunk_index": 0
+    }
+  ],
+  "unique_turns": ["msg_def456"]
+}
+```
+
+### Health Check
+
+```bash
+curl -s "http://127.0.0.1:8766/api/status" | python3 -m json.tool
+```
+
+## Usage Tips
+
+- Search queries work best with natural language descriptions of what you're looking for
+- The vector search uses MiniLM paraphrase-multilingual-L12-v2 embeddings (semantic similarity, not keyword matching)
+- Sessions must be manually indexed via "Import & Index" in Vapor's session window before they appear in search results
+- Each session's conversation is chunked into 512-character segments with 32-character overlap for granular matching
+- Only user and assistant text turns are indexed (tool calls, reasoning, patches are excluded)

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ xcuserdata/
 *.perspectivev3
 !default.perspectivev3
 .DS_Store
+.venv-coreml/
 *.swp
 *~
 Vapor/Resources/ollama

--- a/.opencode/skills/vapor-agent-memory/SKILL.md
+++ b/.opencode/skills/vapor-agent-memory/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vapor-session-search
+name: vapor-agent-memory
 description: "Search Vapor's local indexed agent memory for the current session, including conversation turns and indexed tool/reasoning history."
 ---
 
@@ -31,6 +31,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   | python3 -m json.tool
 ```
 
+Response includes `session_id`, title, directory, and `index_status`.
+
 ## Check Index Status
 
 ```bash
@@ -48,7 +50,17 @@ Status values:
 - `missing`: session is not imported; ask the user to click **Import & Index** in Vapor.
 - `indexing`: indexing is running; try again shortly.
 
+Important fields:
+
+- `can_search`: true if search can be used.
+- `chunks`: number of indexed metadata chunks.
+- `vectors`: number of available searchable vectors.
+- `coverage`: `vectors / chunks`.
+- `message`: user-facing guidance.
+
 ## Search Agent Memory
+
+Current/inferred session:
 
 ```bash
 QUERY="dictation on local device vs cloud based"
@@ -74,11 +86,20 @@ The score is cosine distance. Lower is better.
 - `< 0.60` is related.
 - Larger values are weaker.
 
+Results include:
+
+- `embedding_id`
+- `distance`
+- `chunk_text`
+- `turn_source_id`
+- `session_id`
+- `chunk_index`
+
 ## Expand Context
 
 ```bash
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "$BASE/api/session/ses_abc123/context?q=sqlite%20vec%20filtering&context_turns=2" \
+  "$BASE/api/agent/sessions/ses_abc123/context?q=sqlite%20vec%20filtering&context_turns=2" \
   | python3 -m json.tool
 ```
 

--- a/.opencode/skills/vapor-session-search/SKILL.md
+++ b/.opencode/skills/vapor-session-search/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: vapor-session-search
+description: "Search indexed OpenCode agent sessions via Vapor's local HTTP API. Supports semantic vector search across conversation turns and per-session context retrieval."
+---
+
+# Vapor Session Search
+
+Search indexed agent conversation sessions through Vapor's embedded HTTP API on `127.0.0.1:8766`.
+
+## Prerequisites
+
+- Vapor must be running (macOS app with embedded HTTP server on port 8766)
+- Auth token available via `VAPOR_API_TOKEN` environment variable (auto-set by Vapor on launch)
+- Sessions must be indexed via "Import & Index" in the Vapor UI before they are searchable
+
+## Authentication
+
+All requests require a Bearer token. Use the `VAPOR_API_TOKEN` environment variable:
+
+```bash
+TOKEN=$VAPOR_API_TOKEN
+curl -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=..."
+```
+
+## API Endpoints
+
+### Search Sessions
+
+Semantic vector search across indexed conversation turns.
+
+```bash
+TOKEN=$VAPOR_API_TOKEN
+
+# Search all indexed sessions
+curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=implement+authentication&limit=10" | python3 -m json.tool
+
+# Search within a specific session
+curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=error+handling&session_id=ses_abc123&limit=5" | python3 -m json.tool
+```
+
+**Parameters:**
+- `q` (required): Search query text
+- `session_id` (optional): Scope search to a specific session
+- `limit` (optional, default 20): Max results to return
+
+**Response:**
+```json
+{
+  "results": [
+    {
+      "embedding_id": "turn:ses_abc123:msg_def456:0",
+      "distance": 0.42,
+      "chunk_text": "...relevant text from conversation...",
+      "turn_source_id": "msg_def456",
+      "session_id": "ses_abc123",
+      "chunk_index": 0
+    }
+  ],
+  "count": 1
+}
+```
+
+### Get Session Context
+
+Retrieve search results with full chunk context from surrounding turns.
+
+```bash
+TOKEN=$VAPOR_API_TOKEN
+
+curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/ses_abc123/context?q=authentication+flow&context_turns=2" | python3 -m json.tool
+```
+
+**Parameters:**
+- `session_id` (required, in URL path): Session to search
+- `q` (required): Search query
+- `context_turns` (optional, default 2): Number of surrounding turns to include
+- `limit` (optional, default 5): Max search results
+
+**Response:**
+```json
+{
+  "session_id": "ses_abc123",
+  "query": "authentication flow",
+  "results": [...],
+  "turn_chunks": [
+    {
+      "embedding_id": "turn:ses_abc123:msg_def456:0",
+      "chunk_text": "...full chunk text...",
+      "turn_source_id": "msg_def456",
+      "session_id": "ses_abc123",
+      "chunk_index": 0
+    }
+  ],
+  "unique_turns": ["msg_def456"]
+}
+```
+
+### Health Check
+
+```bash
+curl -s "http://127.0.0.1:8766/api/status" | python3 -m json.tool
+```
+
+## Usage Tips
+
+- Search queries work best with natural language descriptions of what you're looking for
+- The vector search uses MiniLM paraphrase-multilingual-L12-v2 embeddings (semantic similarity, not keyword matching)
+- Sessions must be manually indexed via "Import & Index" in Vapor's session window before they appear in search results
+- Each session's conversation is chunked into 512-character segments with 32-character overlap for granular matching
+- Only user and assistant text turns are indexed (tool calls, reasoning, patches are excluded)

--- a/.opencode/skills/vapor-session-search/SKILL.md
+++ b/.opencode/skills/vapor-session-search/SKILL.md
@@ -1,110 +1,120 @@
 ---
 name: vapor-session-search
-description: "Search indexed OpenCode agent sessions via Vapor's local HTTP API. Supports semantic vector search across conversation turns and per-session context retrieval."
+description: "Search Vapor's local indexed agent memory for the current session, including conversation turns and indexed tool/reasoning history."
 ---
 
-# Vapor Session Search
+# Vapor Agent Memory Search
 
-Search indexed agent conversation sessions through Vapor's embedded HTTP API on `127.0.0.1:8766`.
+Use this skill when you need to recall prior decisions, errors, implementation details, tool results, or reasoning from the current indexed agent session.
 
-## Prerequisites
+Vapor exposes a local HTTP API on `http://127.0.0.1:8766`. Requests require `VAPOR_API_TOKEN` as a Bearer token.
 
-- Vapor must be running (macOS app with embedded HTTP server on port 8766)
-- Auth token available via `VAPOR_API_TOKEN` environment variable (auto-set by Vapor on launch)
-- Sessions must be indexed via "Import & Index" in the Vapor UI before they are searchable
+## Workflow
+
+1. Check index status before searching.
+2. Search only if `can_search` is `true`.
+3. If `can_search` is `false`, tell the user which Vapor UI action is needed.
+4. Use context expansion before relying on a result.
 
 ## Authentication
 
-All requests require a Bearer token. Use the `VAPOR_API_TOKEN` environment variable:
+```bash
+TOKEN="$VAPOR_API_TOKEN"
+BASE="${VAPOR_API_URL:-http://127.0.0.1:8766}"
+```
+
+## Check Current Session
 
 ```bash
-TOKEN=$VAPOR_API_TOKEN
-curl -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=..."
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/current-session?cwd=$(python3 -c 'import os,urllib.parse; print(urllib.parse.quote(os.getcwd()))')" \
+  | python3 -m json.tool
 ```
 
-## API Endpoints
+Response includes `session_id`, title, directory, and `index_status`.
 
-### Search Sessions
-
-Semantic vector search across indexed conversation turns.
+## Check Index Status
 
 ```bash
-TOKEN=$VAPOR_API_TOKEN
-
-# Search all indexed sessions
-curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=implement+authentication&limit=10" | python3 -m json.tool
-
-# Search within a specific session
-curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/search?q=error+handling&session_id=ses_abc123&limit=5" | python3 -m json.tool
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/index/status?session_id=ses_abc123" \
+  | python3 -m json.tool
 ```
 
-**Parameters:**
-- `q` (required): Search query text
-- `session_id` (optional): Scope search to a specific session
-- `limit` (optional, default 20): Max results to return
+Status values:
 
-**Response:**
-```json
-{
-  "results": [
-    {
-      "embedding_id": "turn:ses_abc123:msg_def456:0",
-      "distance": 0.42,
-      "chunk_text": "...relevant text from conversation...",
-      "turn_source_id": "msg_def456",
-      "session_id": "ses_abc123",
-      "chunk_index": 0
-    }
-  ],
-  "count": 1
-}
-```
+- `ready`: search is ready.
+- `dirty`: search is usable but session has newer data; ask the user to click **Update Search** in Vapor.
+- `partial`: search is usable but incomplete; ask the user to click **Update Search** if recall matters.
+- `repair_needed`: search is unavailable; ask the user to click **Repair Search** in Vapor.
+- `missing`: session is not imported; ask the user to click **Import & Index** in Vapor.
+- `indexing`: indexing is running; try again shortly.
 
-### Get Session Context
+Important fields:
 
-Retrieve search results with full chunk context from surrounding turns.
+- `can_search`: true if search can be used.
+- `chunks`: number of indexed metadata chunks.
+- `vectors`: number of available searchable vectors.
+- `coverage`: `vectors / chunks`.
+- `message`: user-facing guidance.
+
+## Search Agent Memory
+
+Current/inferred session:
 
 ```bash
-TOKEN=$VAPOR_API_TOKEN
-
-curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8766/api/session/ses_abc123/context?q=authentication+flow&context_turns=2" | python3 -m json.tool
+QUERY="dictation on local device vs cloud based"
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/search?q=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))' "$QUERY")&limit=10" \
+  | python3 -m json.tool
 ```
 
-**Parameters:**
-- `session_id` (required, in URL path): Session to search
-- `q` (required): Search query
-- `context_turns` (optional, default 2): Number of surrounding turns to include
-- `limit` (optional, default 5): Max search results
-
-**Response:**
-```json
-{
-  "session_id": "ses_abc123",
-  "query": "authentication flow",
-  "results": [...],
-  "turn_chunks": [
-    {
-      "embedding_id": "turn:ses_abc123:msg_def456:0",
-      "chunk_text": "...full chunk text...",
-      "turn_source_id": "msg_def456",
-      "session_id": "ses_abc123",
-      "chunk_index": 0
-    }
-  ],
-  "unique_turns": ["msg_def456"]
-}
-```
-
-### Health Check
+Explicit session:
 
 ```bash
-curl -s "http://127.0.0.1:8766/api/status" | python3 -m json.tool
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/sessions/ses_abc123/search?q=sqlite%20vec%20filtering&limit=10" \
+  | python3 -m json.tool
 ```
 
-## Usage Tips
+Legacy alias:
 
-- Search queries work best with natural language descriptions of what you're looking for
-- The vector search uses MiniLM paraphrase-multilingual-L12-v2 embeddings (semantic similarity, not keyword matching)
-- Sessions must be manually indexed via "Import & Index" in Vapor's session window before they appear in search results
-- Each session's conversation is chunked into 512-character segments with 32-character overlap for granular matching
-- Only user and assistant text turns are indexed (tool calls, reasoning, patches are excluded)
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/session/search?q=sqlite%20vec%20filtering&session_id=ses_abc123&limit=10"
+```
+
+## Interpret Results
+
+The score is cosine distance. Lower is better.
+
+- `0.0` is closest.
+- `< 0.30` is typically strong.
+- `< 0.60` is related.
+- Larger values are weaker.
+
+Results include:
+
+- `embedding_id`
+- `distance`
+- `chunk_text`
+- `turn_source_id`
+- `session_id`
+- `chunk_index`
+
+## Expand Context
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/session/ses_abc123/context?q=sqlite%20vec%20filtering&context_turns=2" \
+  | python3 -m json.tool
+```
+
+Use context expansion before making claims based on a search result.
+
+## Rules
+
+- Prefer current-session search unless the user asks for cross-session recall.
+- Always check status first if search quality matters.
+- If `can_search` is false, do not claim nothing was found; report the required Vapor action.
+- Do not trigger indexing from the API unless the user explicitly asks and the endpoint supports it.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Vapor auto-detects new screenshots on your Desktop. Open the shelf with ⌘⇧S,
 
 Captured pages, articles, browser research in one searchable sidebar. Open with ⌘⌥C, search by keyword, and insert context directly into your prompts. Everything you capture is processed through a pipeline that extracts entities, generates summaries, and builds citations.
 
+### Agent Memory API
+
+Vapor can index local agent sessions and expose them through an authenticated localhost API so agents can search prior conversation history and tool context. See [`docs/agent-memory-api.md`](docs/agent-memory-api.md).
+
 ### Research Interrogation
 
 Scan live browser tabs for structured data: tables, JSON, XHR feeds, articles. Vapor discovers data sources on the pages you have open and captures them into context automatically.

--- a/Vapor/Vapor/Models/AgentConversation.swift
+++ b/Vapor/Vapor/Models/AgentConversation.swift
@@ -48,7 +48,7 @@ final class AgentConversation {
         self.summaryDeletions = summaryDeletions
         self.timeCreated = timeCreated
         self.timeUpdated = timeUpdated
-        self.lastImportedAt = Date()
+        self.lastImportedAt = nil
     }
 
     var projectDisplayName: String {

--- a/Vapor/Vapor/Models/AgentConversation.swift
+++ b/Vapor/Vapor/Models/AgentConversation.swift
@@ -1,0 +1,64 @@
+import Foundation
+import SwiftData
+
+@Model
+final class AgentConversation {
+    var id: UUID
+    var sourceID: String
+    var source: String
+    var parentSourceID: String?
+    var projectSourceID: String?
+    var directory: String
+    var title: String
+    var slug: String?
+    var version: String?
+    var summaryFiles: Int?
+    var summaryAdditions: Int?
+    var summaryDeletions: Int?
+    var timeCreated: Date
+    var timeUpdated: Date
+    var lastImportedAt: Date?
+
+    init(
+        sourceID: String,
+        source: String,
+        parentSourceID: String? = nil,
+        projectSourceID: String? = nil,
+        directory: String,
+        title: String,
+        slug: String? = nil,
+        version: String? = nil,
+        summaryFiles: Int? = nil,
+        summaryAdditions: Int? = nil,
+        summaryDeletions: Int? = nil,
+        timeCreated: Date,
+        timeUpdated: Date
+    ) {
+        self.id = UUID()
+        self.sourceID = sourceID
+        self.source = source
+        self.parentSourceID = parentSourceID
+        self.projectSourceID = projectSourceID
+        self.directory = directory
+        self.title = title
+        self.slug = slug
+        self.version = version
+        self.summaryFiles = summaryFiles
+        self.summaryAdditions = summaryAdditions
+        self.summaryDeletions = summaryDeletions
+        self.timeCreated = timeCreated
+        self.timeUpdated = timeUpdated
+        self.lastImportedAt = Date()
+    }
+
+    var projectDisplayName: String {
+        (directory as NSString).lastPathComponent
+    }
+
+    var diffSummary: String? {
+        guard let files = summaryFiles, files > 0 else { return nil }
+        let adds = summaryAdditions ?? 0
+        let dels = summaryDeletions ?? 0
+        return "+\(adds)/-\(dels) in \(files) files"
+    }
+}

--- a/Vapor/Vapor/Models/AgentSessionPayload.swift
+++ b/Vapor/Vapor/Models/AgentSessionPayload.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct AgentSessionPayload: Identifiable, Hashable, Codable {
+    let id: String
+    let sourceID: String
+
+    init(sourceID: String) {
+        self.id = sourceID
+        self.sourceID = sourceID
+    }
+}

--- a/Vapor/Vapor/Models/AgentTurn.swift
+++ b/Vapor/Vapor/Models/AgentTurn.swift
@@ -1,0 +1,80 @@
+import Foundation
+import SwiftData
+
+@Model
+final class AgentTurn {
+    var id: UUID
+    var sourceID: String
+    var source: String
+    var conversationSourceID: String
+    var role: String
+    var agent: String?
+    var mode: String?
+    var modelID: String?
+    var providerID: String?
+    var cost: Double?
+    var tokensInput: Int?
+    var tokensOutput: Int?
+    var tokensReasoning: Int?
+    var tokensCacheRead: Int?
+    var tokensCacheWrite: Int?
+    var pathCwd: String?
+    var pathRoot: String?
+    var finishReason: String?
+    var timeCreated: Date
+    var timeCompleted: Date?
+    var embeddingID: String?
+
+    init(
+        sourceID: String,
+        source: String,
+        conversationSourceID: String,
+        role: String,
+        agent: String? = nil,
+        mode: String? = nil,
+        modelID: String? = nil,
+        providerID: String? = nil,
+        cost: Double? = nil,
+        tokensInput: Int? = nil,
+        tokensOutput: Int? = nil,
+        tokensReasoning: Int? = nil,
+        tokensCacheRead: Int? = nil,
+        tokensCacheWrite: Int? = nil,
+        pathCwd: String? = nil,
+        pathRoot: String? = nil,
+        finishReason: String? = nil,
+        timeCreated: Date,
+        timeCompleted: Date? = nil
+    ) {
+        self.id = UUID()
+        self.sourceID = sourceID
+        self.source = source
+        self.conversationSourceID = conversationSourceID
+        self.role = role
+        self.agent = agent
+        self.mode = mode
+        self.modelID = modelID
+        self.providerID = providerID
+        self.cost = cost
+        self.tokensInput = tokensInput
+        self.tokensOutput = tokensOutput
+        self.tokensReasoning = tokensReasoning
+        self.tokensCacheRead = tokensCacheRead
+        self.tokensCacheWrite = tokensCacheWrite
+        self.pathCwd = pathCwd
+        self.pathRoot = pathRoot
+        self.finishReason = finishReason
+        self.timeCreated = timeCreated
+        self.timeCompleted = timeCompleted
+        self.embeddingID = nil
+    }
+
+    var totalTokens: Int? {
+        let components = [tokensInput, tokensOutput, tokensReasoning].compactMap { $0 }
+        guard !components.isEmpty else { return nil }
+        return components.reduce(0, +)
+    }
+
+    var isUser: Bool { role == "user" }
+    var isAssistant: Bool { role == "assistant" }
+}

--- a/Vapor/Vapor/Models/TurnContent.swift
+++ b/Vapor/Vapor/Models/TurnContent.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SwiftData
+
+enum TurnContentKind: String, Codable, Sendable {
+    case text
+    case tool
+    case reasoning
+    case patch
+    case file
+    case compaction
+    case stepStart = "step-start"
+    case stepFinish = "step-finish"
+    case unknown
+}
+
+@Model
+final class TurnContent {
+    var id: UUID
+    var sourceID: String
+    var source: String
+    var turnSourceID: String
+    var conversationSourceID: String
+    var kind: String
+    var textContent: String?
+    var toolName: String?
+    var toolStatus: String?
+    var toolTitle: String?
+    var toolInput: String?
+    var toolOutput: String?
+    var patchFiles: [String]?
+    var fileMime: String?
+    var fileFilename: String?
+    var fileURL: String?
+    var timeCreated: Date
+    var embeddingID: String?
+
+    init(
+        sourceID: String,
+        source: String,
+        turnSourceID: String,
+        conversationSourceID: String,
+        kind: String,
+        textContent: String? = nil,
+        toolName: String? = nil,
+        toolStatus: String? = nil,
+        toolTitle: String? = nil,
+        toolInput: String? = nil,
+        toolOutput: String? = nil,
+        patchFiles: [String]? = nil,
+        fileMime: String? = nil,
+        fileFilename: String? = nil,
+        fileURL: String? = nil,
+        timeCreated: Date
+    ) {
+        self.id = UUID()
+        self.sourceID = sourceID
+        self.source = source
+        self.turnSourceID = turnSourceID
+        self.conversationSourceID = conversationSourceID
+        self.kind = kind
+        self.textContent = textContent
+        self.toolName = toolName
+        self.toolStatus = toolStatus
+        self.toolTitle = toolTitle
+        self.toolInput = toolInput
+        self.toolOutput = toolOutput
+        self.patchFiles = patchFiles
+        self.fileMime = fileMime
+        self.fileFilename = fileFilename
+        self.fileURL = fileURL
+        self.timeCreated = timeCreated
+        self.embeddingID = nil
+    }
+
+    var typedKind: TurnContentKind {
+        TurnContentKind(rawValue: kind) ?? .unknown
+    }
+
+    var isText: Bool { kind == TurnContentKind.text.rawValue }
+    var isTool: Bool { kind == TurnContentKind.tool.rawValue }
+    var isReasoning: Bool { kind == TurnContentKind.reasoning.rawValue }
+}

--- a/Vapor/Vapor/Models/UserPreferences.swift
+++ b/Vapor/Vapor/Models/UserPreferences.swift
@@ -12,6 +12,29 @@ enum MaxImageDimension: Int, Codable, CaseIterable, Sendable {
     }
 }
 
+enum AgentSessionRefreshInterval: Double, Codable, CaseIterable, Sendable {
+    case off = 0
+    case tenSeconds = 10
+    case thirtySeconds = 30
+    case oneMinute = 60
+    case fiveMinutes = 300
+
+    var displayName: String {
+        switch self {
+        case .off: "Off"
+        case .tenSeconds: "Every 10 seconds"
+        case .thirtySeconds: "Every 30 seconds"
+        case .oneMinute: "Every 1 minute"
+        case .fiveMinutes: "Every 5 minutes"
+        }
+    }
+
+    var duration: Duration? {
+        guard rawValue > 0 else { return nil }
+        return .seconds(rawValue)
+    }
+}
+
 @MainActor
 @Observable
 final class UserPreferences {
@@ -55,6 +78,9 @@ final class UserPreferences {
     var maxImageDimension: MaxImageDimension {
         didSet { UserDefaults.standard.set(maxImageDimension.rawValue, forKey: Keys.maxImageDimension) }
     }
+    var agentSessionRefreshInterval: AgentSessionRefreshInterval {
+        didSet { UserDefaults.standard.set(agentSessionRefreshInterval.rawValue, forKey: Keys.agentSessionRefreshInterval) }
+    }
 
     struct Keys {
         static let windowExpanded = "windowExpanded"
@@ -70,6 +96,7 @@ final class UserPreferences {
         static let autoSubmitToAI = "autoSubmitToAI"
         static let embeddedServerPort = "embeddedServerPort"
         static let maxImageDimension = "maxImageDimension"
+        static let agentSessionRefreshInterval = "agentSessionRefreshInterval"
     }
 
     init() {
@@ -86,6 +113,12 @@ final class UserPreferences {
         self.embeddedServerPort = UserDefaults.standard.object(forKey: Keys.embeddedServerPort) as? Int ?? 8766
         self.maxImageDimension = UserDefaults.standard.object(forKey: Keys.maxImageDimension)
             .flatMap { MaxImageDimension(rawValue: ($0 as? Int) ?? 0) } ?? .d768
+        self.agentSessionRefreshInterval = UserDefaults.standard.object(forKey: Keys.agentSessionRefreshInterval)
+            .flatMap { value in
+                if let double = value as? Double { return AgentSessionRefreshInterval(rawValue: double) }
+                if let int = value as? Int { return AgentSessionRefreshInterval(rawValue: Double(int)) }
+                return nil
+            } ?? .oneMinute
     }
 
     func saveWindowPosition(_ point: CGPoint) {

--- a/Vapor/Vapor/Models/VaporSchema.swift
+++ b/Vapor/Vapor/Models/VaporSchema.swift
@@ -14,6 +14,9 @@ enum VaporSchemaV1: VersionedSchema {
             ContextItemEntityLink.self,
             ImageAsset.self,
             ContextItemImageLink.self,
+            AgentConversation.self,
+            AgentTurn.self,
+            TurnContent.self,
         ]
     }
 }

--- a/Vapor/Vapor/Services/BrowserBridge.swift
+++ b/Vapor/Vapor/Services/BrowserBridge.swift
@@ -192,6 +192,27 @@ final class BrowserBridge {
                                     "unique_turns": turnSourceIDs
                                 ] as [String: Any]
                             }
+                        },
+                        onAgentIndexStatus: { [weak self] in
+                            return { sessionID, cwd, source in
+                                let vectorization = await MainActor.run { self?.vectorizationService }
+                                return await Self.agentIndexStatus(
+                                    sessionID: sessionID,
+                                    cwd: cwd,
+                                    source: source,
+                                    vectorizationService: vectorization
+                                )
+                            }
+                        },
+                        onAgentCurrentSession: { [weak self] in
+                            return { cwd, source in
+                                let vectorization = await MainActor.run { self?.vectorizationService }
+                                return await Self.agentCurrentSession(
+                                    cwd: cwd,
+                                    source: source,
+                                    vectorizationService: vectorization
+                                )
+                            }
                         }
                     )
                     guard !Task.isCancelled else {
@@ -721,6 +742,168 @@ final class BrowserBridge {
             recordEstimate: json["recordEstimate"] as? Int,
             sizeHint: json["sizeHint"] as? String
         )
+    }
+
+    nonisolated private static func agentCurrentSession(
+        cwd: String?,
+        source: String?,
+        vectorizationService: VectorizationService?
+    ) async -> [String: Any] {
+        guard source == nil || source == "opencode" else {
+            return ["error": "unsupported_source", "source": source ?? ""]
+        }
+        guard let session = inferOpenCodeSession(cwd: cwd) else {
+            return ["error": "no_current_session", "message": "No OpenCode session could be inferred for the supplied cwd."]
+        }
+
+        var body = sessionPayload(session)
+        body["index_status"] = await agentIndexStatus(
+            sessionID: session.id,
+            cwd: cwd,
+            source: source,
+            vectorizationService: vectorizationService
+        )
+        return body
+    }
+
+    nonisolated private static func agentIndexStatus(
+        sessionID: String?,
+        cwd: String?,
+        source: String?,
+        vectorizationService: VectorizationService?
+    ) async -> [String: Any] {
+        guard source == nil || source == "opencode" else {
+            return ["error": "unsupported_source", "source": source ?? ""]
+        }
+        guard let vectorizationService else {
+            return ["error": "vectorization_unavailable", "message": "Vapor vectorization service is not available."]
+        }
+        guard let session = sessionID.flatMap({ OpenCodeReader.shared.fetchSession(sessionID: $0) }) ?? inferOpenCodeSession(cwd: cwd) else {
+            return ["error": "no_session", "message": "No OpenCode session could be inferred. Provide session_id or cwd."]
+        }
+
+        let indexer = await MainActor.run { OpenCodeSessionIndexer.shared }
+        let status = await indexer.checkImportState(
+            sourceID: session.id,
+            sessionTimeUpdated: session.timeUpdated,
+            vectorizationService: vectorizationService
+        )
+        let activeState = await MainActor.run { indexer.state }
+        let isActive = activeIndexInfo(activeState, sessionID: session.id)
+
+        var payload = sessionPayload(session)
+        let statusPayload = statusPayload(status, active: isActive, model: await MainActor.run { vectorizationService.providerDisplayName })
+        for (key, value) in statusPayload { payload[key] = value }
+        return payload
+    }
+
+    nonisolated private static func inferOpenCodeSession(cwd: String?) -> OpenCodeSession? {
+        let reader = OpenCodeReader.shared
+        if let cwd, !cwd.isEmpty,
+           let session = reader.fetchSessions(limit: 1, directory: cwd).first {
+            return session
+        }
+        return reader.fetchSessions(limit: 1).first
+    }
+
+    nonisolated private static func sessionPayload(_ session: OpenCodeSession) -> [String: Any] {
+        return [
+            "source": "opencode",
+            "session_id": session.id,
+            "title": session.title,
+            "directory": session.directory,
+            "updated_at": isoString(session.timeUpdated),
+            "message_count": session.messageCount
+        ]
+    }
+
+    nonisolated private static func statusPayload(
+        _ status: OpenCodeSessionIndexer.ImportStatus,
+        active: [String: Any]?,
+        model: String
+    ) -> [String: Any] {
+        if let active { return active.merging(["model": model]) { current, _ in current } }
+
+        let chunks: Int
+        let vectors: Int
+        let turns: Int
+        let statusString: String
+        let message: String
+        let canSearch: Bool
+        let needsUpdate: Bool
+        let needsRepair: Bool
+
+        switch status {
+        case .notImported:
+            turns = 0; chunks = 0; vectors = 0
+            statusString = "missing"
+            message = "This session is not imported. Ask the user to click Import & Index in Vapor."
+            canSearch = false; needsUpdate = false; needsRepair = false
+        case .ready(let turnCount, let chunkCount, let vectorCount):
+            turns = turnCount; chunks = chunkCount; vectors = vectorCount
+            statusString = "ready"
+            message = "Search is ready."
+            canSearch = true; needsUpdate = false; needsRepair = false
+        case .dirty(let turnCount, let chunkCount, let vectorCount):
+            turns = turnCount; chunks = chunkCount; vectors = vectorCount
+            statusString = vectorCount < chunkCount ? "partial" : "dirty"
+            message = vectorCount < chunkCount
+                ? "Search is usable but incomplete. Ask the user to click Update Search if recall matters."
+                : "The session has newer data. Ask the user to click Update Search in Vapor."
+            canSearch = vectorCount > 0; needsUpdate = true; needsRepair = false
+        case .needsRepair(let turnCount, let chunkCount, let vectorCount):
+            turns = turnCount; chunks = chunkCount; vectors = vectorCount
+            statusString = "repair_needed"
+            message = "Search index is unavailable. Ask the user to click Repair Search in Vapor."
+            canSearch = false; needsUpdate = false; needsRepair = true
+        }
+
+        return [
+            "status": statusString,
+            "usable": canSearch,
+            "can_search": canSearch,
+            "needs_update": needsUpdate,
+            "needs_repair": needsRepair,
+            "turns": turns,
+            "chunks": chunks,
+            "vectors": vectors,
+            "coverage": chunks > 0 ? Double(vectors) / Double(chunks) : 0,
+            "model": model,
+            "message": message
+        ]
+    }
+
+    nonisolated private static func activeIndexInfo(_ state: OpenCodeSessionIndexer.IndexState, sessionID: String) -> [String: Any]? {
+        switch state {
+        case .importing(let id, let current, let total) where id == sessionID:
+            return [
+                "status": "indexing",
+                "usable": false,
+                "can_search": false,
+                "needs_update": false,
+                "needs_repair": false,
+                "progress_current": current,
+                "progress_total": total,
+                "message": total > 0 ? "Importing session: \(current) / \(total)." : "Importing session."
+            ]
+        case .indexing(let id, let current, let total) where id == sessionID:
+            return [
+                "status": "indexing",
+                "usable": false,
+                "can_search": false,
+                "needs_update": false,
+                "needs_repair": false,
+                "progress_current": current,
+                "progress_total": total,
+                "message": total > 0 ? "Updating search index: \(current) / \(total)." : "Updating search index."
+            ]
+        default:
+            return nil
+        }
+    }
+
+    nonisolated private static func isoString(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
     }
 
     func handleContextCapture(_ json: [String: Any]) {

--- a/Vapor/Vapor/Services/BrowserBridge.swift
+++ b/Vapor/Vapor/Services/BrowserBridge.swift
@@ -73,6 +73,7 @@ final class BrowserBridge {
     private static let tokenKey = "browserBridgeAuthToken"
     private static let selectedTargetKey = "browserBridgeSelectedTarget"
     private var contextQueueService: ContextQueueService?
+    private var vectorizationService: VectorizationService?
     let contextStatusCache = ContextStatusCache()
     private var pendingPromptRequest: PendingPromptRequest?
 
@@ -84,18 +85,25 @@ final class BrowserBridge {
         self.contextQueueService = service
     }
 
+    func setVectorizationService(_ service: VectorizationService) {
+        self.vectorizationService = service
+    }
+
     nonisolated func authToken() -> String {
         if let token = UserDefaults.standard.string(forKey: Self.tokenKey), !token.isEmpty {
+            setenv("VAPOR_API_TOKEN", token, 0)
             return token
         }
         let token = UUID().uuidString
         UserDefaults.standard.set(token, forKey: Self.tokenKey)
+        setenv("VAPOR_API_TOKEN", token, 0)
         return token
     }
 
     nonisolated func resetAuthToken() -> String {
         let token = UUID().uuidString
         UserDefaults.standard.set(token, forKey: Self.tokenKey)
+        setenv("VAPOR_API_TOKEN", token, 1)
         Task { @MainActor [weak self] in
             await self?.restartAfterTokenReset()
         }
@@ -158,6 +166,32 @@ final class BrowserBridge {
                         },
                         contextItemStatusProvider: { [weak cache = self.contextStatusCache] jobId in
                             cache?.get(jobId)
+                        },
+                        onSessionSearch: { [weak self] in
+                            return { query, sessionID, limit in
+                                guard let vectorization = await MainActor.run(body: { self?.vectorizationService }) else { return [] }
+                                return await vectorization.searchTurnChunks(matching: query, sessionID: sessionID, limit: limit)
+                            }
+                        },
+                        onSessionContext: { [weak self] in
+                            return { sessionID, query, contextTurns, limit in
+                                guard let vectorization = await MainActor.run(body: { self?.vectorizationService }) else { return nil }
+                                let results = await vectorization.searchTurnChunks(matching: query, sessionID: sessionID, limit: limit)
+                                guard !results.isEmpty else { return nil }
+                                let turnSourceIDs = Array(Set(results.compactMap { $0["turn_source_id"] as? String }))
+                                var allChunks: [[String: Any]] = []
+                                for sourceID in turnSourceIDs {
+                                    let chunks = await vectorization.fetchChunkTexts(turnSourceID: sourceID)
+                                    allChunks.append(contentsOf: chunks)
+                                }
+                                return [
+                                    "session_id": sessionID,
+                                    "query": query,
+                                    "results": results,
+                                    "turn_chunks": allChunks,
+                                    "unique_turns": turnSourceIDs
+                                ] as [String: Any]
+                            }
                         }
                     )
                     guard !Task.isCancelled else {

--- a/Vapor/Vapor/Services/BrowserBridge.swift
+++ b/Vapor/Vapor/Services/BrowserBridge.swift
@@ -167,13 +167,13 @@ final class BrowserBridge {
                         contextItemStatusProvider: { [weak cache = self.contextStatusCache] jobId in
                             cache?.get(jobId)
                         },
-                        onSessionSearch: { [weak self] in
+                        onAgentSearch: { [weak self] in
                             return { query, sessionID, limit in
                                 guard let vectorization = await MainActor.run(body: { self?.vectorizationService }) else { return [] }
                                 return await vectorization.searchTurnChunks(matching: query, sessionID: sessionID, limit: limit)
                             }
                         },
-                        onSessionContext: { [weak self] in
+                        onAgentContext: { [weak self] in
                             return { sessionID, query, contextTurns, limit in
                                 guard let vectorization = await MainActor.run(body: { self?.vectorizationService }) else { return nil }
                                 let results = await vectorization.searchTurnChunks(matching: query, sessionID: sessionID, limit: limit)

--- a/Vapor/Vapor/Services/BrowserBridge.swift
+++ b/Vapor/Vapor/Services/BrowserBridge.swift
@@ -178,18 +178,39 @@ final class BrowserBridge {
                                 guard let vectorization = await MainActor.run(body: { self?.vectorizationService }) else { return nil }
                                 let results = await vectorization.searchTurnChunks(matching: query, sessionID: sessionID, limit: limit)
                                 guard !results.isEmpty else { return nil }
-                                let turnSourceIDs = Array(Set(results.compactMap { $0["turn_source_id"] as? String }))
-                                var allChunks: [[String: Any]] = []
-                                for sourceID in turnSourceIDs {
-                                    let chunks = await vectorization.fetchChunkTexts(turnSourceID: sourceID)
-                                    allChunks.append(contentsOf: chunks)
+                                let reader = OpenCodeReader.shared
+                                let messages = reader.fetchAllMessages(sessionID: sessionID)
+                                let orderedTurnIDs = messages.map(\.id)
+                                let matchedTurnIDs = Self.uniqueOrdered(results.compactMap { $0["turn_source_id"] as? String })
+                                var contextTurnIDs: [String] = []
+                                for turnID in matchedTurnIDs {
+                                    guard let index = orderedTurnIDs.firstIndex(of: turnID) else {
+                                        contextTurnIDs.append(turnID)
+                                        continue
+                                    }
+                                    let lower = max(0, index - contextTurns)
+                                    let upper = min(orderedTurnIDs.count - 1, index + contextTurns)
+                                    contextTurnIDs.append(contentsOf: orderedTurnIDs[lower...upper])
+                                }
+                                contextTurnIDs = Self.uniqueOrdered(contextTurnIDs)
+
+                                var chunksByTurn: [[String: Any]] = []
+                                for turnID in contextTurnIDs {
+                                    let chunks = await vectorization.fetchChunkTexts(turnSourceID: turnID)
+                                    chunksByTurn.append([
+                                        "turn_source_id": turnID,
+                                        "chunks": chunks,
+                                        "is_match": matchedTurnIDs.contains(turnID)
+                                    ])
                                 }
                                 return [
                                     "session_id": sessionID,
                                     "query": query,
+                                    "context_turns": contextTurns,
                                     "results": results,
-                                    "turn_chunks": allChunks,
-                                    "unique_turns": turnSourceIDs
+                                    "turns": chunksByTurn,
+                                    "matched_turns": matchedTurnIDs,
+                                    "context_turn_ids": contextTurnIDs
                                 ] as [String: Any]
                             }
                         },
@@ -726,6 +747,16 @@ final class BrowserBridge {
             return lhs.matchesKnownAIHost && !rhs.matchesKnownAIHost
         }
         return lhs.displayTitle.localizedCaseInsensitiveCompare(rhs.displayTitle) == .orderedAscending
+    }
+
+    nonisolated private static func uniqueOrdered(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for value in values where !seen.contains(value) {
+            seen.insert(value)
+            result.append(value)
+        }
+        return result
     }
 
     private static func parseDiscoveredSource(_ json: [String: Any]) -> DiscoveredSource? {

--- a/Vapor/Vapor/Services/MiniLMEmbeddingService.swift
+++ b/Vapor/Vapor/Services/MiniLMEmbeddingService.swift
@@ -29,7 +29,7 @@ enum MiniLMEmbeddingError: LocalizedError {
 
 final class MiniLMEmbeddingService {
     static let dimensions = 384
-    static let identifier = "minilm_l12_multilingual_v2"
+    static let identifier = "minilm_l6_v2"
 
     private var model: MLModel?
     private var tokenizer: MiniLMTokenizer?
@@ -41,24 +41,51 @@ final class MiniLMEmbeddingService {
     func initialize() async throws {
         if model != nil, tokenizer != nil { return }
 
-        if tokenizer == nil {
-            tokenizer = try MiniLMTokenizer()
-        }
+        let loadedTokenizer = try MiniLMTokenizer()
 
         guard let modelURL = resolveModelURL() else {
             miniLMLogger.error("MiniLM model not found in bundle or fallback locations")
             throw MiniLMEmbeddingError.modelNotFound
         }
 
-        model = try loadModel(from: modelURL)
+        let loadedModel = try await Self.loadModelAsync(from: modelURL)
+
+        self.tokenizer = loadedTokenizer
+        self.model = loadedModel
         miniLMLogger.info("Loaded MiniLM model from \(modelURL.path, privacy: .public)")
     }
 
+    private static func loadModelAsync(from modelURL: URL) async throws -> MLModel {
+        try await Task.detached {
+            Result { try Self.loadModelFile(from: modelURL) }
+        }.value.get()
+    }
+
+    private static func loadModelFile(from modelURL: URL) throws -> MLModel {
+        let configuration = MLModelConfiguration()
+        configuration.computeUnits = .cpuOnly
+
+        if modelURL.pathExtension == "mlmodel" || modelURL.pathExtension == "mlpackage" {
+            let compiledURL = try MLModel.compileModel(at: modelURL)
+            return try MLModel(contentsOf: compiledURL, configuration: configuration)
+        }
+
+        return try MLModel(contentsOf: modelURL, configuration: configuration)
+    }
+
     private func resolveModelURL() -> URL? {
-        let modelName = "paraphrase-multilingual-MiniLM-L12-v2-512tokens"
+        let modelName = "all-MiniLM-L6-v2"
+
+        if let sourcePackage = candidateModelURLs().first(where: { $0.pathExtension == "mlpackage" && FileManager.default.fileExists(atPath: $0.path) }) {
+            return sourcePackage
+        }
 
         if let compiledURL = Bundle.main.url(forResource: modelName, withExtension: "mlmodelc") {
             return compiledURL
+        }
+
+        if let packageURL = Bundle.main.url(forResource: modelName, withExtension: "mlpackage") {
+            return packageURL
         }
 
         if let sourceURL = Bundle.main.url(forResource: modelName, withExtension: "mlmodel") {
@@ -69,19 +96,11 @@ final class MiniLMEmbeddingService {
     }
 
     private func loadModel(from modelURL: URL) throws -> MLModel {
-        let configuration = MLModelConfiguration()
-        configuration.computeUnits = .all
-
-        if modelURL.pathExtension == "mlmodel" {
-            let compiledURL = try MLModel.compileModel(at: modelURL)
-            return try MLModel(contentsOf: compiledURL, configuration: configuration)
-        }
-
-        return try MLModel(contentsOf: modelURL, configuration: configuration)
+        try Self.loadModelFile(from: modelURL)
     }
 
     private func candidateModelURLs() -> [URL] {
-        let modelName = "paraphrase-multilingual-MiniLM-L12-v2-512tokens"
+        let modelName = "all-MiniLM-L6-v2"
         let environment = ProcessInfo.processInfo.environment
         var candidates: [URL] = []
 
@@ -102,6 +121,7 @@ final class MiniLMEmbeddingService {
 
         for directory in resourceDirectories.compactMap({ $0 }) {
             candidates.append(directory.appendingPathComponent("\(modelName).mlmodelc", isDirectory: true))
+            candidates.append(directory.appendingPathComponent("\(modelName).mlpackage", isDirectory: true))
             candidates.append(directory.appendingPathComponent("\(modelName).mlmodel"))
         }
 
@@ -132,20 +152,25 @@ final class MiniLMEmbeddingService {
             throw MiniLMEmbeddingError.invalidModelOutput
         }
 
-        return l2Normalize(floatArray(from: embeddings))
+        let shapeDescription = String(describing: embeddings.shape.map { $0.intValue })
+        miniLMLogger.debug("MiniLM embeddings shape: \(shapeDescription, privacy: .public), count: \(embeddings.count), type: \(String(describing: embeddings.dataType), privacy: .public)")
+
+        let vector = floatArray(from: embeddings)
+        guard vector.count == Self.dimensions else {
+            miniLMLogger.error("MiniLM embedding dimension mismatch: expected \(Self.dimensions), got \(vector.count)")
+            throw MiniLMEmbeddingError.invalidModelOutput
+        }
+
+        return l2Normalize(vector)
     }
 
     private func extractEmbeddings(from output: MLFeatureProvider) -> MLMultiArray? {
         if let embeddings = output.featureValue(for: "embeddings")?.multiArrayValue {
+            miniLMLogger.info("Using MiniLM output feature embeddings")
             return embeddings
         }
 
-        for featureName in output.featureNames.sorted() {
-            if let multiArray = output.featureValue(for: featureName)?.multiArrayValue {
-                miniLMLogger.info("Using MiniLM output feature \(featureName, privacy: .public)")
-                return multiArray
-            }
-        }
+        miniLMLogger.error("MiniLM embeddings output missing. Available features: \(output.featureNames.sorted().joined(separator: ", "), privacy: .public)")
 
         return nil
     }
@@ -339,13 +364,13 @@ private extension MLMultiArray {
 
         let multiArray: MLMultiArray
         do {
-            multiArray = try MLMultiArray(shape: shape as [NSNumber], dataType: .int32)
+            multiArray = try MLMultiArray(shape: shape as [NSNumber], dataType: .float32)
         } catch {
             fatalError("Failed to create MLMultiArray for MiniLM input: \(error.localizedDescription)")
         }
-        let pointer = UnsafeMutablePointer<Int32>(OpaquePointer(multiArray.dataPointer))
+        let pointer = multiArray.dataPointer.bindMemory(to: Float.self, capacity: values.count)
         for (index, value) in values.enumerated() {
-            pointer[index] = Int32(value)
+            pointer[index] = Float(value)
         }
         return multiArray
     }

--- a/Vapor/Vapor/Services/OpenCodeReader.swift
+++ b/Vapor/Vapor/Services/OpenCodeReader.swift
@@ -1,0 +1,633 @@
+import Foundation
+import OSLog
+import CSQLiteVec
+
+private let openCodeLogger = Logger(subsystem: "lol.mrl.app.Vapor", category: "OpenCodeReader")
+
+struct OpenCodeSession: Identifiable, Sendable {
+    let id: String
+    let projectID: String
+    let directory: String
+    let title: String
+    let slug: String
+    let messageCount: Int
+    let timeCreated: Date
+    let timeUpdated: Date
+    let version: String?
+    let summaryFiles: Int?
+    let summaryAdditions: Int?
+    let summaryDeletions: Int?
+
+    var projectDisplayName: String {
+        (directory as NSString).lastPathComponent
+    }
+}
+
+struct OpenCodeMessage: Identifiable, Sendable {
+    let id: String
+    let sessionID: String
+    let role: String
+    let agent: String?
+    let mode: String?
+    let modelID: String?
+    let providerID: String?
+    let cost: Double?
+    let tokens: TokenInfo?
+    let pathCwd: String?
+    let pathRoot: String?
+    let timeCreated: Date
+    let timeCompleted: Date?
+    let finishReason: String?
+}
+
+struct TokenInfo: Sendable {
+    let total: Int
+    let input: Int
+    let output: Int
+    let reasoning: Int
+    let cacheRead: Int
+    let cacheWrite: Int
+}
+
+enum OpenCodePartKind: Sendable {
+    case text(String)
+    case tool(name: String, callID: String?, status: String, input: String?, output: String?, title: String?)
+    case reasoning(String)
+    case stepStart(String)
+    case stepFinish(reason: String?, cost: Double?, tokens: TokenInfo?)
+    case patch(String, files: [String])
+    case file(mime: String, filename: String?, url: String?)
+    case compaction(auto: Bool)
+    case unknown
+}
+
+struct OpenCodePart: Identifiable, Sendable {
+    let id: String
+    let messageID: String
+    let sessionID: String
+    let kind: OpenCodePartKind
+    let timeCreated: Date
+}
+
+final class OpenCodeReader: Sendable {
+
+    static let shared = OpenCodeReader()
+
+    private static let knownPaths: [URL] = {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return [
+            home.appendingPathComponent(".local/share/opencode/opencode.db"),
+            home.appendingPathComponent("Library/Application Support/opencode/opencode.db")
+        ]
+    }()
+
+    private let _databaseURL: URL?
+    private var db: OpaquePointer?
+    private let queue = DispatchQueue(label: "lol.mrl.app.Vapor.opencode-reader", qos: .userInitiated)
+
+    private init() {
+        var found: URL?
+        for path in Self.knownPaths {
+            if FileManager.default.isReadableFile(atPath: path.path) {
+                found = path
+                openCodeLogger.info("Found opencode.db at: \(path.path)")
+                break
+            } else {
+                openCodeLogger.info("No opencode.db at: \(path.path)")
+            }
+        }
+        if found == nil {
+            openCodeLogger.warning("No opencode.db found in any known path")
+        }
+        _databaseURL = found
+
+        if let path = found?.path {
+            openDatabase(at: path)
+        }
+    }
+
+    deinit {
+        let ptr = db
+        db = nil
+        if let ptr { sqlite3_close(ptr) }
+    }
+
+    var isAvailable: Bool {
+        _databaseURL != nil && db != nil
+    }
+
+    var databasePath: String? {
+        _databaseURL?.path
+    }
+
+    func resolveDatabasePath() -> String? {
+        _databaseURL?.path
+    }
+
+    // MARK: - Raw Data Extraction (for indexer)
+
+    func fetchSessionsRaw(sinceEpoch: Int = 0) -> [[String: String]] {
+        let whereClause = sinceEpoch > 0 ? "WHERE time_updated > \(sinceEpoch)" : ""
+        let sql = """
+            SELECT id, project_id, parent_id, directory, title, slug,
+                   version, time_created, time_updated,
+                   summary_files, summary_additions, summary_deletions
+            FROM session
+            \(whereClause)
+            ORDER BY time_updated DESC
+            """
+        return query(sql)
+    }
+
+    func fetchMessagesRaw(sessionIDs: [String], sinceEpoch: Int = 0) -> [[String: String]] {
+        guard !sessionIDs.isEmpty else { return [] }
+        let ids = sessionIDs.map { "'\(sqlEscape($0))'" }.joined(separator: ",")
+        let timeClause = sinceEpoch > 0 ? "AND time_updated > \(sinceEpoch)" : ""
+        let sql = """
+            SELECT id, session_id, data, time_created, time_updated
+            FROM message
+            WHERE session_id IN (\(ids))
+            \(timeClause)
+            ORDER BY time_created ASC
+            """
+        return query(sql)
+    }
+
+    func fetchPartsRaw(sessionIDs: [String], sinceEpoch: Int = 0) -> [[String: String]] {
+        guard !sessionIDs.isEmpty else { return [] }
+        let ids = sessionIDs.map { "'\(sqlEscape($0))'" }.joined(separator: ",")
+        let timeClause = sinceEpoch > 0 ? "AND time_updated > \(sinceEpoch)" : ""
+        let sql = """
+            SELECT id, message_id, session_id, data, time_created
+            FROM part
+            WHERE session_id IN (\(ids))
+            \(timeClause)
+            ORDER BY time_created ASC
+            """
+        return query(sql)
+    }
+
+    func parseConversationRow(_ row: [String: String]) -> AgentConversation {
+        AgentConversation(
+            sourceID: row["id"] ?? "",
+            source: "opencode",
+            parentSourceID: row["parent_id"].flatMap { $0.isEmpty ? nil : $0 },
+            projectSourceID: row["project_id"],
+            directory: row["directory"] ?? "",
+            title: row["title"] ?? "",
+            slug: row["slug"],
+            version: row["version"],
+            summaryFiles: row["summary_files"].flatMap { Int($0) },
+            summaryAdditions: row["summary_additions"].flatMap { Int($0) },
+            summaryDeletions: row["summary_deletions"].flatMap { Int($0) },
+            timeCreated: parseEpochMs(row["time_created"]),
+            timeUpdated: parseEpochMs(row["time_updated"])
+        )
+    }
+
+    func parseTurnRow(_ row: [String: String]) -> AgentTurn {
+        let data = parseDataJSON(row["data"])
+        return AgentTurn(
+            sourceID: row["id"] ?? "",
+            source: "opencode",
+            conversationSourceID: row["session_id"] ?? "",
+            role: data["role"] as? String ?? "unknown",
+            agent: data["agent"] as? String,
+            mode: data["mode"] as? String,
+            modelID: data["modelID"] as? String ?? parseNestedString(data["model"], key: "modelID"),
+            providerID: data["providerID"] as? String ?? parseNestedString(data["model"], key: "providerID"),
+            cost: data["cost"] as? Double,
+            tokensInput: parseNestedInt(data["tokens"], key: "input"),
+            tokensOutput: parseNestedInt(data["tokens"], key: "output"),
+            tokensReasoning: parseNestedInt(data["tokens"], key: "reasoning"),
+            tokensCacheRead: parseNestedDoubleNested(data["tokens"], inner: "cache", key: "read").flatMap { Int($0) },
+            tokensCacheWrite: parseNestedDoubleNested(data["tokens"], inner: "cache", key: "write").flatMap { Int($0) },
+            pathCwd: (data["path"] as? [String: Any])?["cwd"] as? String,
+            pathRoot: (data["path"] as? [String: Any])?["root"] as? String,
+            finishReason: data["finish"] as? String,
+            timeCreated: parseEpochMs(row["time_created"]),
+            timeCompleted: parseCompletedTime(data["time"] as? [String: Any])
+        )
+    }
+
+    func parseContentRow(_ row: [String: String]) -> TurnContent {
+        let data = parseDataJSON(row["data"])
+        let partType = data["type"] as? String ?? ""
+
+        switch partType {
+        case "text":
+            return TurnContent(
+                sourceID: row["id"] ?? "",
+                source: "opencode",
+                turnSourceID: row["message_id"] ?? "",
+                conversationSourceID: row["session_id"] ?? "",
+                kind: TurnContentKind.text.rawValue,
+                textContent: data["text"] as? String,
+                timeCreated: parseEpochMs(row["time_created"])
+            )
+        case "tool":
+            let state = data["state"] as? [String: Any] ?? [:]
+            return TurnContent(
+                sourceID: row["id"] ?? "",
+                source: "opencode",
+                turnSourceID: row["message_id"] ?? "",
+                conversationSourceID: row["session_id"] ?? "",
+                kind: TurnContentKind.tool.rawValue,
+                toolName: data["tool"] as? String,
+                toolStatus: state["status"] as? String,
+                toolTitle: data["title"] as? String ?? state["title"] as? String,
+                toolInput: stringifyToolInput(state["input"]),
+                toolOutput: state["output"] as? String,
+                timeCreated: parseEpochMs(row["time_created"])
+            )
+        case "reasoning":
+            return TurnContent(
+                sourceID: row["id"] ?? "",
+                source: "opencode",
+                turnSourceID: row["message_id"] ?? "",
+                conversationSourceID: row["session_id"] ?? "",
+                kind: TurnContentKind.reasoning.rawValue,
+                textContent: data["text"] as? String,
+                timeCreated: parseEpochMs(row["time_created"])
+            )
+        case "step-start":
+            return TurnContent(
+                sourceID: row["id"] ?? "",
+                source: "opencode",
+                turnSourceID: row["message_id"] ?? "",
+                conversationSourceID: row["session_id"] ?? "",
+                kind: TurnContentKind.stepStart.rawValue,
+                timeCreated: parseEpochMs(row["time_created"])
+            )
+        case "step-finish":
+            return TurnContent(
+                sourceID: row["id"] ?? "",
+                source: "opencode",
+                turnSourceID: row["message_id"] ?? "",
+                conversationSourceID: row["session_id"] ?? "",
+                kind: TurnContentKind.stepFinish.rawValue,
+                timeCreated: parseEpochMs(row["time_created"])
+            )
+        case "patch":
+            return TurnContent(
+                sourceID: row["id"] ?? "",
+                source: "opencode",
+                turnSourceID: row["message_id"] ?? "",
+                conversationSourceID: row["session_id"] ?? "",
+                kind: TurnContentKind.patch.rawValue,
+                patchFiles: data["files"] as? [String],
+                timeCreated: parseEpochMs(row["time_created"])
+            )
+        case "file":
+            return TurnContent(
+                sourceID: row["id"] ?? "",
+                source: "opencode",
+                turnSourceID: row["message_id"] ?? "",
+                conversationSourceID: row["session_id"] ?? "",
+                kind: TurnContentKind.file.rawValue,
+                fileMime: data["mime"] as? String,
+                fileFilename: data["filename"] as? String,
+                fileURL: data["url"] as? String,
+                timeCreated: parseEpochMs(row["time_created"])
+            )
+        case "compaction":
+            return TurnContent(
+                sourceID: row["id"] ?? "",
+                source: "opencode",
+                turnSourceID: row["message_id"] ?? "",
+                conversationSourceID: row["session_id"] ?? "",
+                kind: TurnContentKind.compaction.rawValue,
+                timeCreated: parseEpochMs(row["time_created"])
+            )
+        default:
+            return TurnContent(
+                sourceID: row["id"] ?? "",
+                source: "opencode",
+                turnSourceID: row["message_id"] ?? "",
+                conversationSourceID: row["session_id"] ?? "",
+                kind: TurnContentKind.unknown.rawValue,
+                timeCreated: parseEpochMs(row["time_created"])
+            )
+        }
+    }
+
+    // MARK: - Session Queries (sidebar browsing)
+
+    func fetchSessions(limit: Int = 50, offset: Int = 0, directory: String? = nil) -> [OpenCodeSession] {
+        let whereClause = directory.map { "WHERE s.directory = '\(sqlEscape($0))'" } ?? ""
+        let sql = """
+            SELECT s.id, s.project_id, s.directory, s.title, s.slug,
+                   s.version, s.time_created, s.time_updated,
+                   s.summary_files, s.summary_additions, s.summary_deletions,
+                   (SELECT COUNT(*) FROM message m WHERE m.session_id = s.id) as message_count
+            FROM session s
+            \(whereClause)
+            ORDER BY s.time_updated DESC
+            LIMIT \(limit) OFFSET \(offset)
+            """
+
+        return query(sql).map { row in
+            OpenCodeSession(
+                id: row["id"] ?? "",
+                projectID: row["project_id"] ?? "",
+                directory: row["directory"] ?? "",
+                title: row["title"] ?? "",
+                slug: row["slug"] ?? "",
+                messageCount: Int(row["message_count"] ?? "0") ?? 0,
+                timeCreated: parseEpochMs(row["time_created"]),
+                timeUpdated: parseEpochMs(row["time_updated"]),
+                version: row["version"],
+                summaryFiles: row["summary_files"].flatMap { Int($0) },
+                summaryAdditions: row["summary_additions"].flatMap { Int($0) },
+                summaryDeletions: row["summary_deletions"].flatMap { Int($0) }
+            )
+        }
+    }
+
+    func fetchDirectories() -> [(directory: String, sessionCount: Int)] {
+        let sql = """
+            SELECT directory, COUNT(*) as cnt
+            FROM session
+            GROUP BY directory
+            ORDER BY cnt DESC
+            """
+
+        return query(sql).map { row in
+            (directory: row["directory"] ?? "", sessionCount: Int(row["cnt"] ?? "0") ?? 0)
+        }
+    }
+
+    func fetchMessages(sessionID: String, limit: Int = 100) -> [OpenCodeMessage] {
+        let sql = """
+            SELECT id, session_id, data, time_created, time_updated
+            FROM message
+            WHERE session_id = '\(sqlEscape(sessionID))'
+            ORDER BY time_created ASC
+            LIMIT \(limit)
+            """
+
+        return query(sql).map { parseMessage(row: $0) }
+    }
+
+    func fetchAllMessages(sessionID: String) -> [OpenCodeMessage] {
+        let sql = """
+            SELECT id, session_id, data, time_created, time_updated
+            FROM message
+            WHERE session_id = '\(sqlEscape(sessionID))'
+            ORDER BY time_created ASC
+            """
+
+        return query(sql).map { parseMessage(row: $0) }
+    }
+
+    func fetchParts(messageID: String) -> [OpenCodePart] {
+        let sql = """
+            SELECT id, message_id, session_id, data, time_created
+            FROM part
+            WHERE message_id = '\(sqlEscape(messageID))'
+            ORDER BY time_created ASC
+            """
+
+        return query(sql).map { parsePart(row: $0) }
+    }
+
+    func fetchAllParts(sessionID: String) -> [OpenCodePart] {
+        let sql = """
+            SELECT p.id, p.message_id, p.session_id, p.data, p.time_created
+            FROM part p
+            WHERE p.session_id = '\(sqlEscape(sessionID))'
+            ORDER BY p.time_created ASC
+            """
+
+        return query(sql).map { parsePart(row: $0) }
+    }
+
+    func messageCount(sessionID: String) -> Int {
+        let sql = "SELECT COUNT(*) as cnt FROM message WHERE session_id = '\(sqlEscape(sessionID))'"
+        let rows = query(sql)
+        return Int(rows.first?["cnt"] ?? "0") ?? 0
+    }
+
+    func totalSessionCount() -> Int {
+        let sql = "SELECT COUNT(*) as cnt FROM session"
+        let rows = query(sql)
+        return Int(rows.first?["cnt"] ?? "0") ?? 0
+    }
+
+    func totalDirectoryCount() -> Int {
+        let sql = "SELECT COUNT(DISTINCT directory) as cnt FROM session"
+        let rows = query(sql)
+        return Int(rows.first?["cnt"] ?? "0") ?? 0
+    }
+
+    func sessionTimeUpdated(sessionID: String) -> Date? {
+        let sql = "SELECT time_updated FROM session WHERE id = '\(sqlEscape(sessionID))'"
+        let rows = query(sql)
+        guard let value = rows.first?["time_updated"] else { return nil }
+        let epochMs = Double(value)
+        guard let epochMs else { return nil }
+        return Date(timeIntervalSince1970: epochMs / 1000.0)
+    }
+
+    // MARK: - Private
+
+    private func openDatabase(at path: String) {
+        var ptr: OpaquePointer?
+        let rc = sqlite3_open_v2(path, &ptr, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nil)
+        guard rc == SQLITE_OK else {
+            openCodeLogger.error("Failed to open opencode.db: \(String(cString: sqlite3_errmsg(ptr)))")
+            return
+        }
+        sqlite3_busy_timeout(ptr, 5000)
+        self.db = ptr
+        openCodeLogger.info("Opened opencode.db (read-only, 5s busy timeout)")
+    }
+
+    private func query(_ sql: String) -> [[String: String]] {
+        queue.sync { () -> [[String: String]] in
+            guard let db else { return [] }
+
+            var statement: OpaquePointer?
+            let rc = sqlite3_prepare_v2(db, sql, -1, &statement, nil)
+            guard rc == SQLITE_OK, let statement else {
+                let msg = String(cString: sqlite3_errmsg(db))
+                openCodeLogger.error("SQL prepare failed: \(msg) — sql: \(sql.prefix(200))")
+                return []
+            }
+            defer { sqlite3_finalize(statement) }
+
+            let colCount = sqlite3_column_count(statement)
+            var results: [[String: String]] = []
+            results.reserveCapacity(64)
+
+            while sqlite3_step(statement) == SQLITE_ROW {
+                var row: [String: String] = [:]
+                row.reserveCapacity(Int(colCount))
+                for col in 0..<Int(colCount) {
+                    let col32 = Int32(col)
+                    let name = String(cString: sqlite3_column_name(statement, col32))
+                    let type = sqlite3_column_type(statement, col32)
+                    switch type {
+                    case SQLITE_NULL:
+                        row[name] = ""
+                    case SQLITE_INTEGER:
+                        row[name] = String(sqlite3_column_int64(statement, col32))
+                    case SQLITE_FLOAT:
+                        row[name] = String(sqlite3_column_double(statement, col32))
+                    default:
+                        if let text = sqlite3_column_text(statement, col32) {
+                            row[name] = String(cString: text)
+                        } else {
+                            row[name] = ""
+                        }
+                    }
+                }
+                results.append(row)
+            }
+
+            return results
+        }
+    }
+
+    private func parseMessage(row: [String: String]) -> OpenCodeMessage {
+        let data = parseDataJSON(row["data"])
+
+        return OpenCodeMessage(
+            id: row["id"] ?? "",
+            sessionID: row["session_id"] ?? "",
+            role: data["role"] as? String ?? "unknown",
+            agent: data["agent"] as? String,
+            mode: data["mode"] as? String,
+            modelID: data["modelID"] as? String ?? (data["model"] as? [String: Any])?["modelID"] as? String,
+            providerID: data["providerID"] as? String ?? (data["model"] as? [String: Any])?["providerID"] as? String,
+            cost: data["cost"] as? Double,
+            tokens: parseTokens(data["tokens"] as? [String: Any]),
+            pathCwd: (data["path"] as? [String: Any])?["cwd"] as? String,
+            pathRoot: (data["path"] as? [String: Any])?["root"] as? String,
+            timeCreated: parseEpochMs(row["time_created"]),
+            timeCompleted: parseCompletedTime(data["time"] as? [String: Any]),
+            finishReason: data["finish"] as? String
+        )
+    }
+
+    private func parsePart(row: [String: String]) -> OpenCodePart {
+        let data = parseDataJSON(row["data"])
+        let partType = data["type"] as? String ?? ""
+
+        let kind: OpenCodePartKind
+        switch partType {
+        case "text":
+            kind = .text(data["text"] as? String ?? "")
+        case "tool":
+            let state = data["state"] as? [String: Any] ?? [:]
+            let input = stringifyToolInput(state["input"])
+            let output = (state["output"] as? String) ?? ""
+            kind = .tool(
+                name: data["tool"] as? String ?? "unknown",
+                callID: data["callID"] as? String,
+                status: state["status"] as? String ?? "unknown",
+                input: input,
+                output: output,
+                title: data["title"] as? String ?? state["title"] as? String
+            )
+        case "reasoning":
+            kind = .reasoning(data["text"] as? String ?? "")
+        case "step-start":
+            kind = .stepStart(data["snapshot"] as? String ?? "")
+        case "step-finish":
+            kind = .stepFinish(
+                reason: data["reason"] as? String,
+                cost: data["cost"] as? Double,
+                tokens: parseTokens(data["tokens"] as? [String: Any])
+            )
+        case "patch":
+            let hash = data["hash"] as? String ?? ""
+            let files = data["files"] as? [String] ?? []
+            kind = .patch(hash, files: files)
+        case "file":
+            kind = .file(
+                mime: data["mime"] as? String ?? "",
+                filename: data["filename"] as? String,
+                url: data["url"] as? String
+            )
+        case "compaction":
+            kind = .compaction(auto: data["auto"] as? Bool ?? false)
+        default:
+            kind = .unknown
+        }
+
+        return OpenCodePart(
+            id: row["id"] ?? "",
+            messageID: row["message_id"] ?? "",
+            sessionID: row["session_id"] ?? "",
+            kind: kind,
+            timeCreated: parseEpochMs(row["time_created"])
+        )
+    }
+
+    private func parseDataJSON(_ raw: String?) -> [String: Any] {
+        guard let raw, let data = raw.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return json
+    }
+
+    private func parseTokens(_ dict: [String: Any]?) -> TokenInfo? {
+        guard let dict else { return nil }
+        let cache = dict["cache"] as? [String: Any] ?? [:]
+        return TokenInfo(
+            total: dict["total"] as? Int ?? 0,
+            input: dict["input"] as? Int ?? 0,
+            output: dict["output"] as? Int ?? 0,
+            reasoning: dict["reasoning"] as? Int ?? 0,
+            cacheRead: cache["read"] as? Int ?? 0,
+            cacheWrite: cache["write"] as? Int ?? 0
+        )
+    }
+
+    private func parseCompletedTime(_ timeDict: [String: Any]?) -> Date? {
+        guard let completed = timeDict?["completed"] as? Int else { return nil }
+        return Date(timeIntervalSince1970: Double(completed) / 1000.0)
+    }
+
+    private func parseEpochMs(_ value: String?) -> Date {
+        guard let value, let epochMs = Double(value) else { return .distantPast }
+        return Date(timeIntervalSince1970: epochMs / 1000.0)
+    }
+
+    private func parseNestedString(_ parent: Any?, key: String) -> String? {
+        (parent as? [String: Any])?[key] as? String
+    }
+
+    private func parseNestedInt(_ parent: Any?, key: String) -> Int? {
+        (parent as? [String: Any])?[key] as? Int
+    }
+
+    private func parseNestedDoubleNested(_ parent: Any?, inner: String, key: String) -> Double? {
+        guard let outer = parent as? [String: Any],
+              let innerDict = outer[inner] as? [String: Any] else { return nil }
+        return innerDict[key] as? Double
+    }
+
+    private func stringifyToolInput(_ input: Any?) -> String? {
+        guard let input else { return nil }
+        if let str = input as? String { return str }
+        if let dict = input as? [String: Any] {
+            if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+               let str = String(data: data, encoding: .utf8) {
+                return str
+            }
+        }
+        if let arr = input as? [Any],
+           let data = try? JSONSerialization.data(withJSONObject: arr, options: [.sortedKeys]),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        return String(describing: input)
+    }
+
+    private func sqlEscape(_ value: String) -> String {
+        value.replacingOccurrences(of: "'", with: "''")
+    }
+}

--- a/Vapor/Vapor/Services/OpenCodeReader.swift
+++ b/Vapor/Vapor/Services/OpenCodeReader.swift
@@ -388,6 +388,18 @@ final class OpenCodeReader: Sendable {
         }
     }
 
+    func sessionListSignature(directory: String? = nil) -> String {
+        let directoryClause = directory.map { "AND s.directory = '\(sqlEscape($0))'" } ?? ""
+        let sql = """
+            SELECT COUNT(*) || ':' || COALESCE(MAX(s.time_updated), 0) AS signature
+            FROM session s
+            WHERE EXISTS (SELECT 1 FROM message m WHERE m.session_id = s.id)
+            \(directoryClause)
+            """
+        let rows = query(sql)
+        return rows.first?["signature"] ?? "0:0"
+    }
+
     func fetchMessages(sessionID: String, limit: Int = 100) -> [OpenCodeMessage] {
         let sql = """
             SELECT id, session_id, data, time_created, time_updated

--- a/Vapor/Vapor/Services/OpenCodeReader.swift
+++ b/Vapor/Vapor/Services/OpenCodeReader.swift
@@ -314,14 +314,15 @@ final class OpenCodeReader: Sendable {
     // MARK: - Session Queries (sidebar browsing)
 
     func fetchSessions(limit: Int = 50, offset: Int = 0, directory: String? = nil) -> [OpenCodeSession] {
-        let whereClause = directory.map { "WHERE s.directory = '\(sqlEscape($0))'" } ?? ""
+        let directoryClause = directory.map { "AND s.directory = '\(sqlEscape($0))'" } ?? ""
         let sql = """
             SELECT s.id, s.project_id, s.directory, s.title, s.slug,
                    s.version, s.time_created, s.time_updated,
                    s.summary_files, s.summary_additions, s.summary_deletions,
                    (SELECT COUNT(*) FROM message m WHERE m.session_id = s.id) as message_count
             FROM session s
-            \(whereClause)
+            WHERE EXISTS (SELECT 1 FROM message m WHERE m.session_id = s.id)
+            \(directoryClause)
             ORDER BY s.time_updated DESC
             LIMIT \(limit) OFFSET \(offset)
             """
@@ -375,9 +376,10 @@ final class OpenCodeReader: Sendable {
 
     func fetchDirectories() -> [(directory: String, sessionCount: Int)] {
         let sql = """
-            SELECT directory, COUNT(*) as cnt
-            FROM session
-            GROUP BY directory
+            SELECT s.directory, COUNT(*) as cnt
+            FROM session s
+            WHERE EXISTS (SELECT 1 FROM message m WHERE m.session_id = s.id)
+            GROUP BY s.directory
             ORDER BY cnt DESC
             """
 
@@ -438,7 +440,7 @@ final class OpenCodeReader: Sendable {
     }
 
     func totalSessionCount() -> Int {
-        let sql = "SELECT COUNT(*) as cnt FROM session"
+        let sql = "SELECT COUNT(*) as cnt FROM session s WHERE EXISTS (SELECT 1 FROM message m WHERE m.session_id = s.id)"
         let rows = query(sql)
         return Int(rows.first?["cnt"] ?? "0") ?? 0
     }

--- a/Vapor/Vapor/Services/OpenCodeReader.swift
+++ b/Vapor/Vapor/Services/OpenCodeReader.swift
@@ -344,6 +344,35 @@ final class OpenCodeReader: Sendable {
         }
     }
 
+    func fetchSession(sessionID: String) -> OpenCodeSession? {
+        let sql = """
+            SELECT s.id, s.project_id, s.directory, s.title, s.slug,
+                   s.version, s.time_created, s.time_updated,
+                   s.summary_files, s.summary_additions, s.summary_deletions,
+                   (SELECT COUNT(*) FROM message m WHERE m.session_id = s.id) as message_count
+            FROM session s
+            WHERE s.id = '\(sqlEscape(sessionID))'
+            LIMIT 1
+            """
+
+        return query(sql).first.map { row in
+            OpenCodeSession(
+                id: row["id"] ?? "",
+                projectID: row["project_id"] ?? "",
+                directory: row["directory"] ?? "",
+                title: row["title"] ?? "",
+                slug: row["slug"] ?? "",
+                messageCount: Int(row["message_count"] ?? "0") ?? 0,
+                timeCreated: parseEpochMs(row["time_created"]),
+                timeUpdated: parseEpochMs(row["time_updated"]),
+                version: row["version"],
+                summaryFiles: row["summary_files"].flatMap { Int($0) },
+                summaryAdditions: row["summary_additions"].flatMap { Int($0) },
+                summaryDeletions: row["summary_deletions"].flatMap { Int($0) }
+            )
+        }
+    }
+
     func fetchDirectories() -> [(directory: String, sessionCount: Int)] {
         let sql = """
             SELECT directory, COUNT(*) as cnt

--- a/Vapor/Vapor/Services/OpenCodeSessionIndexer.swift
+++ b/Vapor/Vapor/Services/OpenCodeSessionIndexer.swift
@@ -254,6 +254,7 @@ final class OpenCodeSessionIndexer {
 
             let embedStart = CFAbsoluteTimeGetCurrent()
             let textParts = rawParts.filter { ($0["data"] ?? "").contains("\"type\":\"text\"") }
+            let textPartsByMessageID = Dictionary(grouping: textParts) { $0["message_id"] ?? "" }
             let totalTurns = importedTurns.count
 
             onProgress(.indexing(sourceID: sourceID, current: 0, total: totalTurns))
@@ -262,20 +263,13 @@ final class OpenCodeSessionIndexer {
             var processed = 0
 
             for (index, turnSourceID) in importedTurns.enumerated() {
-                let alreadyHas = await vectorizationService.hasTurnVectors(turnSourceID: turnSourceID)
-                if alreadyHas {
-                    processed += 1
-                    if processed % 100 == 0 {
-                        onProgress(.indexing(sourceID: sourceID, current: index + 1, total: totalTurns))
-                    }
-                    continue
-                }
-
-                let turnParts = textParts.filter { $0["message_id"] == turnSourceID }
+                let turnParts = textPartsByMessageID[turnSourceID] ?? []
                 let textContent = turnParts.compactMap { Self.parseTextFromDataJSON($0["data"]) }.joined(separator: "\n\n")
                 let hasText = !textContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
                 processed += 1
+
+                await vectorizationService.removeTurnEmbeddings(turnSourceID: turnSourceID)
 
                 if hasText {
                     let chunks = TextChunker.chunk(textContent)
@@ -351,6 +345,7 @@ final class OpenCodeSessionIndexer {
             }
 
             let textParts = rawParts.filter { ($0["data"] ?? "").contains("\"type\":\"text\"") }
+            let textPartsByMessageID = Dictionary(grouping: textParts) { $0["message_id"] ?? "" }
             let totalTurns = importedTurns.count
 
             onProgress(.indexing(sourceID: sourceID, current: 0, total: totalTurns))
@@ -359,7 +354,7 @@ final class OpenCodeSessionIndexer {
             var processed = 0
 
             for (index, turnSourceID) in importedTurns.enumerated() {
-                let turnParts = textParts.filter { $0["message_id"] == turnSourceID }
+                let turnParts = textPartsByMessageID[turnSourceID] ?? []
                 let textContent = turnParts.compactMap { Self.parseTextFromDataJSON($0["data"]) }.joined(separator: "\n\n")
                 let hasText = !textContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 

--- a/Vapor/Vapor/Services/OpenCodeSessionIndexer.swift
+++ b/Vapor/Vapor/Services/OpenCodeSessionIndexer.swift
@@ -1,0 +1,559 @@
+import Foundation
+import SwiftData
+import OSLog
+
+private let indexerLogger = Logger(subsystem: "lol.mrl.app.Vapor", category: "OpenCodeSessionIndexer")
+
+@Observable
+@MainActor
+final class OpenCodeSessionIndexer {
+
+    static let shared = OpenCodeSessionIndexer()
+
+    enum IndexState: Equatable, Sendable {
+        case idle
+        case importing(sourceID: String, current: Int, total: Int)
+        case indexing(sourceID: String, current: Int, total: Int)
+        case done(sourceID: String, turnCount: Int, chunkCount: Int)
+        case error(String)
+    }
+
+    enum ImportStatus: Equatable {
+        case notImported
+        case ready(turnCount: Int, chunkCount: Int, vectorCount: Int)
+        case dirty(turnCount: Int, chunkCount: Int, vectorCount: Int)
+        case needsRepair(turnCount: Int, chunkCount: Int, vectorCount: Int)
+    }
+
+    private(set) var state: IndexState = .idle
+    private(set) var isProcessing = false
+    private(set) var importStatuses: [String: ImportStatus] = [:]
+
+    private var container: ModelContainer?
+
+    private init() {}
+
+    func setModelContainer(_ container: ModelContainer) {
+        self.container = container
+    }
+
+    func status(for sourceID: String) -> ImportStatus {
+        importStatuses[sourceID] ?? .notImported
+    }
+
+    func importAndIndex(sourceID: String, vectorizationService: VectorizationService) {
+        guard !isProcessing, let container else { return }
+        isProcessing = true
+
+        let service = vectorizationService
+
+        Task.detached { @Sendable [container, sourceID, service] in
+            let result = await Self.executeImportAndIndex(
+                sourceID: sourceID,
+                container: container,
+                vectorizationService: service,
+                onProgress: { newState in
+                    Task { @MainActor [weak self] in self?.state = newState }
+                }
+            )
+            await MainActor.run { [weak self] in
+                switch result {
+                case let .success(turnCount, chunkCount):
+                    self?.state = .done(sourceID: sourceID, turnCount: turnCount, chunkCount: chunkCount)
+                case let .failure(message):
+                    self?.state = .error(message)
+                }
+                self?.isProcessing = false
+                Task { @MainActor [weak self] in
+                    await self?.refreshImportState(sourceID: sourceID, vectorizationService: service)
+                }
+            }
+        }
+    }
+
+    func checkImportState(sourceID: String, sessionTimeUpdated: Date, vectorizationService: VectorizationService) async -> ImportStatus {
+        guard let container else {
+            importStatuses[sourceID] = .notImported
+            return .notImported
+        }
+
+        let bgContext = ModelContext(container)
+        var descriptor = FetchDescriptor<AgentConversation>(
+            predicate: #Predicate { $0.sourceID == sourceID }
+        )
+        descriptor.fetchLimit = 1
+
+        guard let conversation = try? bgContext.fetch(descriptor).first else {
+            importStatuses[sourceID] = .notImported
+            return .notImported
+        }
+
+        let turnDescriptor = FetchDescriptor<AgentTurn>(
+            predicate: #Predicate { $0.conversationSourceID == sourceID }
+        )
+        let turnCount = (try? bgContext.fetch(turnDescriptor).count) ?? 0
+
+        let chunkCount = await vectorizationService.turnChunkCount(sessionID: sourceID)
+        let vectorCount = await vectorizationService.turnVectorCount(sessionID: sourceID)
+
+        let status: ImportStatus
+        if chunkCount > 0, vectorCount >= chunkCount {
+            if let lastImportedAt = conversation.lastImportedAt, lastImportedAt >= sessionTimeUpdated {
+                status = .ready(turnCount: turnCount, chunkCount: chunkCount, vectorCount: vectorCount)
+            } else {
+                status = .dirty(turnCount: turnCount, chunkCount: chunkCount, vectorCount: vectorCount)
+            }
+        } else if vectorCount > 0 {
+            status = .dirty(turnCount: turnCount, chunkCount: chunkCount, vectorCount: vectorCount)
+        } else if turnCount > 0 || chunkCount > 0 || vectorCount > 0 {
+            status = .needsRepair(turnCount: turnCount, chunkCount: chunkCount, vectorCount: vectorCount)
+        } else {
+            status = .notImported
+        }
+        importStatuses[sourceID] = status
+        return status
+    }
+
+    func refreshImportState(sourceID: String, vectorizationService: VectorizationService) async {
+        let sessionTimeUpdated = OpenCodeReader.shared.sessionTimeUpdated(sessionID: sourceID) ?? Date.distantPast
+        _ = await checkImportState(
+            sourceID: sourceID,
+            sessionTimeUpdated: sessionTimeUpdated,
+            vectorizationService: vectorizationService
+        )
+    }
+
+    func repairSearchIndex(sourceID: String, vectorizationService: VectorizationService) {
+        guard !isProcessing, let container else { return }
+        isProcessing = true
+        state = .indexing(sourceID: sourceID, current: 0, total: 0)
+
+        let service = vectorizationService
+
+        Task.detached { @Sendable [container, sourceID, service] in
+            do {
+                try await service.clearTurnVectors(sessionID: sourceID)
+            } catch {
+                indexerLogger.error("Failed to clear search vectors for repair: \(error.localizedDescription)")
+            }
+
+            let result = await Self.executeRetryEmbedding(
+                sourceID: sourceID,
+                container: container,
+                vectorizationService: service,
+                onProgress: { newState in
+                    Task { @MainActor [weak self] in self?.state = newState }
+                }
+            )
+            await MainActor.run { [weak self] in
+                switch result {
+                case let .success(turnCount, chunkCount):
+                    self?.state = .done(sourceID: sourceID, turnCount: turnCount, chunkCount: chunkCount)
+                case let .failure(message):
+                    self?.state = .error(message)
+                }
+                self?.isProcessing = false
+                Task { @MainActor [weak self] in
+                    await self?.refreshImportState(sourceID: sourceID, vectorizationService: service)
+                }
+            }
+        }
+    }
+
+    func retryEmbedding(sourceID: String, vectorizationService: VectorizationService) {
+        guard !isProcessing, let container else { return }
+        isProcessing = true
+
+        let service = vectorizationService
+
+        Task.detached { @Sendable [container, sourceID, service] in
+            let result = await Self.executeRetryEmbedding(
+                sourceID: sourceID,
+                container: container,
+                vectorizationService: service,
+                onProgress: { newState in
+                    Task { @MainActor [weak self] in self?.state = newState }
+                }
+            )
+            await MainActor.run { [weak self] in
+                switch result {
+                case let .success(turnCount, chunkCount):
+                    self?.state = .done(sourceID: sourceID, turnCount: turnCount, chunkCount: chunkCount)
+                case let .failure(message):
+                    self?.state = .error(message)
+                }
+                self?.isProcessing = false
+                Task { @MainActor [weak self] in
+                    await self?.refreshImportState(sourceID: sourceID, vectorizationService: service)
+                }
+            }
+        }
+    }
+
+    // MARK: - Nonisolated Workers
+
+    private enum ImportResult {
+        case success(turnCount: Int, chunkCount: Int)
+        case failure(String)
+    }
+
+    nonisolated private static func executeImportAndIndex(
+        sourceID: String,
+        container: ModelContainer,
+        vectorizationService: VectorizationService,
+        onProgress: @Sendable @escaping (IndexState) -> Void
+    ) async -> ImportResult {
+        let reader = OpenCodeReader.shared
+        let bgContext = ModelContext(container)
+
+        do {
+            onProgress(.importing(sourceID: sourceID, current: 0, total: 0))
+
+            let fetchStart = CFAbsoluteTimeGetCurrent()
+            let rawSessions = reader.fetchSessionsRaw()
+            guard let rawSession = rawSessions.first(where: { $0["id"] == sourceID }) else {
+                return .failure("Session not found: \(sourceID)")
+            }
+
+            let conv = reader.parseConversationRow(rawSession)
+            Self.upsertConversation(conv, in: bgContext)
+            try bgContext.save()
+
+            let rawMessages = reader.fetchMessagesRaw(sessionIDs: [sourceID])
+            let totalMessages = rawMessages.count
+            var importedTurns: [String] = []
+
+            for (index, raw) in rawMessages.enumerated() {
+                let turn = reader.parseTurnRow(raw)
+                Self.upsertTurn(turn, in: bgContext)
+                importedTurns.append(turn.sourceID)
+                if index % 200 == 0 {
+                    onProgress(.importing(sourceID: sourceID, current: index, total: totalMessages))
+                }
+            }
+
+            try bgContext.save()
+
+            let rawParts = reader.fetchPartsRaw(sessionIDs: [sourceID])
+            for raw in rawParts {
+                let content = reader.parseContentRow(raw)
+                Self.upsertContent(content, in: bgContext)
+            }
+
+            try bgContext.save()
+
+            let fetchElapsed = CFAbsoluteTimeGetCurrent() - fetchStart
+            indexerLogger.info("Import phase complete for \(sourceID): \(totalMessages) messages, \(rawParts.count) parts, \(String(format: "%.1f", fetchElapsed))s")
+
+            await vectorizationService.initialize()
+            let isReady = await MainActor.run(body: { vectorizationService.isReady })
+            guard isReady else {
+                indexerLogger.warning("Vectorization service not ready, skipping embedding")
+                return .success(turnCount: importedTurns.count, chunkCount: 0)
+            }
+
+            let embedStart = CFAbsoluteTimeGetCurrent()
+            let textParts = rawParts.filter { ($0["data"] ?? "").contains("\"type\":\"text\"") }
+            let totalTurns = importedTurns.count
+
+            onProgress(.indexing(sourceID: sourceID, current: 0, total: totalTurns))
+
+            var totalChunks = 0
+            var processed = 0
+
+            for (index, turnSourceID) in importedTurns.enumerated() {
+                let alreadyHas = await vectorizationService.hasTurnVectors(turnSourceID: turnSourceID)
+                if alreadyHas {
+                    processed += 1
+                    if processed % 100 == 0 {
+                        onProgress(.indexing(sourceID: sourceID, current: index + 1, total: totalTurns))
+                    }
+                    continue
+                }
+
+                let turnParts = textParts.filter { $0["message_id"] == turnSourceID }
+                let textContent = turnParts.compactMap { Self.parseTextFromDataJSON($0["data"]) }.joined(separator: "\n\n")
+                let hasText = !textContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+                processed += 1
+
+                if hasText {
+                    let chunks = TextChunker.chunk(textContent)
+                    var batch: [(embeddingID: String, text: String, turnSourceID: String, sessionID: String, chunkIndex: Int)] = []
+                    for (chunkIndex, chunk) in chunks.enumerated() {
+                        batch.append((
+                            embeddingID: "turn:\(sourceID):\(turnSourceID):\(chunkIndex)",
+                            text: chunk,
+                            turnSourceID: turnSourceID,
+                            sessionID: sourceID,
+                            chunkIndex: chunkIndex
+                        ))
+                    }
+                    if !batch.isEmpty {
+                        let stored = (try? await vectorizationService.embedAndStoreBatch(chunks: batch)) ?? 0
+                        totalChunks += stored
+                    }
+                }
+
+                if processed % 100 == 0 || processed == totalTurns {
+                    onProgress(.indexing(sourceID: sourceID, current: index + 1, total: totalTurns))
+                }
+
+                if processed % 5 == 0 {
+                    await Task.yield()
+                }
+            }
+
+            let embedElapsed = CFAbsoluteTimeGetCurrent() - embedStart
+            indexerLogger.info("Embedding phase complete for \(sourceID): \(totalChunks) chunks in \(String(format: "%.1f", embedElapsed))s")
+
+            let updateContext = ModelContext(container)
+            var descriptor = FetchDescriptor<AgentConversation>(
+                predicate: #Predicate { $0.sourceID == sourceID }
+            )
+            descriptor.fetchLimit = 1
+            if let existing = try? updateContext.fetch(descriptor).first {
+                existing.lastImportedAt = Date()
+                try updateContext.save()
+            }
+
+            await vectorizationService.refreshVectorCount()
+
+            indexerLogger.info("Import & index complete for \(sourceID): \(importedTurns.count) turns, \(totalChunks) chunks")
+            return .success(turnCount: importedTurns.count, chunkCount: totalChunks)
+
+        } catch {
+            indexerLogger.error("Import & index failed for \(sourceID): \(error.localizedDescription)")
+            return .failure(error.localizedDescription)
+        }
+    }
+
+    nonisolated private static func executeRetryEmbedding(
+        sourceID: String,
+        container: ModelContainer,
+        vectorizationService: VectorizationService,
+        onProgress: @Sendable @escaping (IndexState) -> Void
+    ) async -> ImportResult {
+        let reader = OpenCodeReader.shared
+
+        do {
+            onProgress(.indexing(sourceID: sourceID, current: 0, total: 0))
+
+            let rawMessages = reader.fetchMessagesRaw(sessionIDs: [sourceID])
+            let importedTurns = rawMessages.compactMap { $0["id"] }
+            let rawParts = reader.fetchPartsRaw(sessionIDs: [sourceID])
+
+            await vectorizationService.initialize()
+            let isReady = await MainActor.run(body: { vectorizationService.isReady })
+            guard isReady else {
+                indexerLogger.warning("Vectorization service not ready during retry")
+                return .failure("Vectorization service not ready")
+            }
+
+            let textParts = rawParts.filter { ($0["data"] ?? "").contains("\"type\":\"text\"") }
+            let totalTurns = importedTurns.count
+
+            onProgress(.indexing(sourceID: sourceID, current: 0, total: totalTurns))
+
+            var totalChunks = 0
+            var processed = 0
+
+            for (index, turnSourceID) in importedTurns.enumerated() {
+                let turnParts = textParts.filter { $0["message_id"] == turnSourceID }
+                let textContent = turnParts.compactMap { Self.parseTextFromDataJSON($0["data"]) }.joined(separator: "\n\n")
+                let hasText = !textContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+                processed += 1
+
+                if hasText {
+                    await vectorizationService.removeTurnEmbeddings(turnSourceID: turnSourceID)
+
+                    let chunks = TextChunker.chunk(textContent)
+                    var batch: [(embeddingID: String, text: String, turnSourceID: String, sessionID: String, chunkIndex: Int)] = []
+                    for (chunkIndex, chunk) in chunks.enumerated() {
+                        batch.append((
+                            embeddingID: "turn:\(sourceID):\(turnSourceID):\(chunkIndex)",
+                            text: chunk,
+                            turnSourceID: turnSourceID,
+                            sessionID: sourceID,
+                            chunkIndex: chunkIndex
+                        ))
+                    }
+                    if !batch.isEmpty {
+                        let stored = (try? await vectorizationService.embedAndStoreBatch(chunks: batch)) ?? 0
+                        totalChunks += stored
+                    }
+                }
+
+                if processed % 100 == 0 || processed == totalTurns {
+                    onProgress(.indexing(sourceID: sourceID, current: index + 1, total: totalTurns))
+                }
+
+                if processed % 5 == 0 {
+                    await Task.yield()
+                }
+            }
+
+            let bgContext = ModelContext(container)
+            var descriptor = FetchDescriptor<AgentConversation>(
+                predicate: #Predicate { $0.sourceID == sourceID }
+            )
+            descriptor.fetchLimit = 1
+            if let existing = try? bgContext.fetch(descriptor).first {
+                existing.lastImportedAt = Date()
+                try bgContext.save()
+            }
+
+            await vectorizationService.refreshVectorCount()
+
+            indexerLogger.info("Retry embedding complete for \(sourceID): \(importedTurns.count) turns, \(totalChunks) chunks")
+            return .success(turnCount: importedTurns.count, chunkCount: totalChunks)
+
+        } catch {
+            indexerLogger.error("Retry embedding failed for \(sourceID): \(error.localizedDescription)")
+            return .failure(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Upsert Helpers
+
+    nonisolated private static func upsertConversation(_ conv: AgentConversation, in context: ModelContext) {
+        let sourceID = conv.sourceID
+        var descriptor = FetchDescriptor<AgentConversation>(
+            predicate: #Predicate { $0.sourceID == sourceID }
+        )
+        descriptor.fetchLimit = 1
+        if let existing = try? context.fetch(descriptor).first {
+            existing.title = conv.title
+            existing.timeUpdated = conv.timeUpdated
+            existing.summaryFiles = conv.summaryFiles
+            existing.summaryAdditions = conv.summaryAdditions
+            existing.summaryDeletions = conv.summaryDeletions
+            existing.version = conv.version
+            existing.lastImportedAt = conv.lastImportedAt
+        } else {
+            context.insert(conv)
+        }
+    }
+
+    nonisolated private static func upsertTurn(_ turn: AgentTurn, in context: ModelContext) {
+        let sourceID = turn.sourceID
+        var descriptor = FetchDescriptor<AgentTurn>(
+            predicate: #Predicate { $0.sourceID == sourceID }
+        )
+        descriptor.fetchLimit = 1
+        if let existing = try? context.fetch(descriptor).first {
+            existing.cost = turn.cost
+            existing.tokensInput = turn.tokensInput
+            existing.tokensOutput = turn.tokensOutput
+            existing.tokensReasoning = turn.tokensReasoning
+            existing.tokensCacheRead = turn.tokensCacheRead
+            existing.tokensCacheWrite = turn.tokensCacheWrite
+            existing.finishReason = turn.finishReason
+            existing.timeCompleted = turn.timeCompleted
+        } else {
+            context.insert(turn)
+        }
+    }
+
+    nonisolated private static func upsertContent(_ content: TurnContent, in context: ModelContext) {
+        let sourceID = content.sourceID
+        var descriptor = FetchDescriptor<TurnContent>(
+            predicate: #Predicate { $0.sourceID == sourceID }
+        )
+        descriptor.fetchLimit = 1
+        if let existing = try? context.fetch(descriptor).first {
+            existing.textContent = content.textContent
+            existing.toolStatus = content.toolStatus
+            existing.toolOutput = content.toolOutput
+        } else {
+            context.insert(content)
+        }
+    }
+
+    // MARK: - Helpers
+
+    nonisolated private static func parseTextFromDataJSON(_ raw: String?) -> String? {
+        guard let raw, let data = raw.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let text = json["text"] as? String, !text.isEmpty else { return nil }
+        return text
+    }
+
+    enum IndexerError: LocalizedError {
+        case sessionNotFound(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .sessionNotFound(let id): "Session not found: \(id)"
+            }
+        }
+    }
+}
+
+// MARK: - Text Chunker
+
+enum TextChunker {
+
+    static let chunkSize = 1_400
+    static let overlap = 180
+    static let wordBoundaryTolerance = 50
+
+    static func chunk(_ text: String) -> [String] {
+        let cleaned = normalizeWhitespace(text)
+        guard cleaned.count > chunkSize else { return cleaned.isEmpty ? [] : [cleaned] }
+
+        var chunks: [String] = []
+        var currentStart = cleaned.startIndex
+        var overlapText: Substring = ""
+
+        while currentStart < cleaned.endIndex {
+            let endBound = cleaned.index(currentStart, offsetBy: chunkSize, limitedBy: cleaned.endIndex) ?? cleaned.endIndex
+            let endPosition = optimizedChunkEnd(in: cleaned, from: currentStart, to: endBound)
+
+            var chunk = String(overlapText) + String(cleaned[currentStart..<endPosition])
+            chunk = chunk.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !chunk.isEmpty { chunks.append(chunk) }
+
+            let overlapStartIndex = cleaned.index(endPosition, offsetBy: -overlap, limitedBy: currentStart) ?? currentStart
+            overlapText = extractWordBoundaryOverlap(in: cleaned, from: overlapStartIndex, to: endPosition)
+
+            if endPosition == cleaned.endIndex { break }
+            currentStart = cleaned.index(after: endPosition)
+        }
+
+        return chunks
+    }
+
+    private static func normalizeWhitespace(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\t", with: " ")
+            .replacingOccurrences(of: "  +", with: " ", options: .regularExpression)
+    }
+
+    private static func optimizedChunkEnd(in text: String, from start: String.Index, to proposedEnd: String.Index) -> String.Index {
+        let limit = text.index(proposedEnd, offsetBy: -wordBoundaryTolerance, limitedBy: start) ?? start
+        var searchFrom = text.index(before: proposedEnd)
+        while searchFrom > limit {
+            let char = text[searchFrom]
+            if char.isWhitespace || char == "." || char == "," || char == ";" || char == ":" || char == "!" || char == "?" {
+                return text.index(after: searchFrom)
+            }
+            searchFrom = text.index(before: searchFrom)
+        }
+        return proposedEnd
+    }
+
+    private static func extractWordBoundaryOverlap(in text: String, from start: String.Index, to end: String.Index) -> Substring {
+        var searchFrom = start
+        let limit = text.index(start, offsetBy: 20, limitedBy: end) ?? end
+        while searchFrom < limit {
+            if text[searchFrom].isWhitespace {
+                return text[searchFrom..<end]
+            }
+            searchFrom = text.index(after: searchFrom)
+        }
+        return text[start..<end]
+    }
+}

--- a/Vapor/Vapor/Services/OpenCodeSessionIndexer.swift
+++ b/Vapor/Vapor/Services/OpenCodeSessionIndexer.swift
@@ -18,7 +18,7 @@ final class OpenCodeSessionIndexer {
         case error(String)
     }
 
-    enum ImportStatus: Equatable {
+    enum ImportStatus: Equatable, Sendable {
         case notImported
         case ready(turnCount: Int, chunkCount: Int, vectorCount: Int)
         case dirty(turnCount: Int, chunkCount: Int, vectorCount: Int)

--- a/Vapor/Vapor/Services/TurnVectorStore.swift
+++ b/Vapor/Vapor/Services/TurnVectorStore.swift
@@ -1,0 +1,234 @@
+import Foundation
+import SQLiteVec
+
+struct TurnVectorChunk: Sendable, Equatable {
+    let embeddingID: String
+    let text: String
+    let turnSourceID: String
+    let sessionID: String
+    let chunkIndex: Int
+}
+
+struct TurnVectorMatch: Sendable, Equatable {
+    let embeddingID: String
+    let distance: Double
+    let chunkText: String
+    let turnSourceID: String
+    let sessionID: String
+    let chunkIndex: Int
+}
+
+struct TurnVectorStore: Sendable {
+    let database: Database
+    let turnTableName: String
+    let chunksTableName: String
+    let dimensions: Int
+    let embed: @Sendable (String) async throws -> [Float]
+
+    static func initializeSchema(
+        database: Database,
+        turnTableName: String,
+        chunksTableName: String,
+        dimensions: Int
+    ) async throws {
+        do {
+            let tableInfo = try await database.query("PRAGMA table_info(\(turnTableName))")
+            if tableInfo.isEmpty {
+                try await database.execute(
+                    "CREATE VIRTUAL TABLE \(turnTableName) USING vec0(embedding float[\(dimensions)], embedding_id TEXT)"
+                )
+            }
+        } catch {
+            try await database.execute(
+                "CREATE VIRTUAL TABLE \(turnTableName) USING vec0(embedding float[\(dimensions)], embedding_id TEXT)"
+            )
+        }
+
+        do {
+            let tableInfo = try await database.query("PRAGMA table_info(\(chunksTableName))")
+            if tableInfo.isEmpty {
+                try await createChunksTable(database: database, chunksTableName: chunksTableName)
+            }
+        } catch {
+            try await createChunksTable(database: database, chunksTableName: chunksTableName)
+        }
+    }
+
+    func hasTurnVectors(turnSourceID: String) async -> Bool {
+        do {
+            let rows = try await database.query(
+                "SELECT COUNT(*) AS count FROM \(turnTableName) WHERE embedding_id LIKE ?",
+                params: ["%:\(turnSourceID):%"]
+            )
+            if let count = rows.first?["count"] {
+                return Self.integerValue(from: count) > 0
+            }
+            return false
+        } catch {
+            return false
+        }
+    }
+
+    func turnChunkCount(sessionID: String) async -> Int {
+        do {
+            let rows = try await database.query(
+                "SELECT COUNT(*) AS count FROM \(chunksTableName) WHERE session_id = ?",
+                params: [sessionID]
+            )
+            if let count = rows.first?["count"] {
+                return Self.integerValue(from: count)
+            }
+            return 0
+        } catch {
+            return 0
+        }
+    }
+
+    func turnVectorCount(sessionID: String) async -> Int {
+        do {
+            let rows = try await database.query(
+                "SELECT COUNT(*) AS count FROM \(turnTableName) WHERE embedding_id LIKE ?",
+                params: ["turn:\(sessionID):%"]
+            )
+            if let count = rows.first?["count"] {
+                return Self.integerValue(from: count)
+            }
+            return 0
+        } catch {
+            return 0
+        }
+    }
+
+    func removeTurnEmbeddings(turnSourceID: String) async throws {
+        let rows = try await database.query(
+            "SELECT embedding_id FROM \(turnTableName) WHERE embedding_id LIKE ?",
+            params: ["%:\(turnSourceID):%"]
+        )
+        for row in rows {
+            if let id = row["embedding_id"] as? String {
+                try await database.execute("DELETE FROM \(turnTableName) WHERE embedding_id = ?", params: [id])
+                try await database.execute("DELETE FROM \(chunksTableName) WHERE embedding_id = ?", params: [id])
+            }
+        }
+    }
+
+    func embedAndStore(_ chunks: [TurnVectorChunk]) async throws -> Int {
+        var storedCount = 0
+        for chunk in chunks {
+            let trimmed = chunk.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+
+            let embedding = try await embed(trimmed)
+            try await upsertTurn(embedding: embedding, id: chunk.embeddingID)
+            try await database.execute(
+                "INSERT OR REPLACE INTO \(chunksTableName) (embedding_id, chunk_text, turn_source_id, session_id, chunk_index) VALUES (?, ?, ?, ?, ?)",
+                params: [chunk.embeddingID, trimmed, chunk.turnSourceID, chunk.sessionID, chunk.chunkIndex]
+            )
+            storedCount += 1
+        }
+        return storedCount
+    }
+
+    func search(matching query: String, sessionID: String? = nil, limit: Int = 20) async throws -> [TurnVectorMatch] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        let queryEmbedding = try await embed(trimmed)
+        let idPrefix: String
+        let metadataCount: Int
+        let vectorCount: Int
+        if let sessionID {
+            idPrefix = "turn:\(sessionID):"
+            metadataCount = await turnChunkCount(sessionID: sessionID)
+            vectorCount = await turnVectorCount(sessionID: sessionID)
+        } else {
+            idPrefix = "turn:"
+            let metadataRows = try await database.query("SELECT COUNT(*) AS count FROM \(chunksTableName)")
+            let vectorRows = try await database.query("SELECT COUNT(*) AS count FROM \(turnTableName)")
+            metadataCount = metadataRows.first?["count"].map(Self.integerValue(from:)) ?? 0
+            vectorCount = vectorRows.first?["count"].map(Self.integerValue(from:)) ?? 0
+        }
+
+        guard vectorCount > 0 else { return [] }
+        let searchLimit = min(max(metadataCount, vectorCount, limit * 250, 5_000), max(vectorCount, 1))
+        let rows = try await database.query(
+            "SELECT embedding_id, vec_distance_cosine(embedding, ?) AS distance FROM \(turnTableName) ORDER BY distance ASC LIMIT ?",
+            params: [queryEmbedding, searchLimit]
+        )
+
+        var matchingIDs: [String] = []
+        var distanceMap: [String: Double] = [:]
+        for row in rows {
+            guard let id = row["embedding_id"] as? String, id.hasPrefix(idPrefix) else { continue }
+            guard let distance = Self.doubleValue(from: row["distance"]) else { continue }
+            matchingIDs.append(id)
+            distanceMap[id] = distance
+            if matchingIDs.count >= limit { break }
+        }
+
+        guard !matchingIDs.isEmpty else { return [] }
+        let placeholders = matchingIDs.map { _ in "?" }.joined(separator: ",")
+        let chunkRows = try await database.query(
+            "SELECT embedding_id, chunk_text, turn_source_id, session_id, chunk_index FROM \(chunksTableName) WHERE embedding_id IN (\(placeholders))",
+            params: matchingIDs
+        )
+
+        return chunkRows.compactMap { row in
+            guard let embeddingID = row["embedding_id"] as? String,
+                  let distance = distanceMap[embeddingID] else { return nil }
+            return TurnVectorMatch(
+                embeddingID: embeddingID,
+                distance: distance,
+                chunkText: row["chunk_text"] as? String ?? "",
+                turnSourceID: row["turn_source_id"] as? String ?? "",
+                sessionID: row["session_id"] as? String ?? "",
+                chunkIndex: Self.integerValue(from: row["chunk_index"] ?? 0)
+            )
+        }
+        .sorted { $0.distance < $1.distance }
+    }
+
+    private static func createChunksTable(database: Database, chunksTableName: String) async throws {
+        try await database.execute(
+            """
+            CREATE TABLE \(chunksTableName) (
+                embedding_id TEXT PRIMARY KEY,
+                chunk_text TEXT NOT NULL,
+                turn_source_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                chunk_index INTEGER NOT NULL
+            )
+            """
+        )
+    }
+
+    private func upsertTurn(embedding: [Float], id: String) async throws {
+        try await database.execute("DELETE FROM \(turnTableName) WHERE embedding_id = ?", params: [id])
+        try await database.execute(
+            "INSERT INTO \(turnTableName)(embedding, embedding_id) VALUES (?, ?)",
+            params: [embedding, id]
+        )
+    }
+
+    private static func integerValue(from value: Any) -> Int {
+        switch value {
+        case let int as Int: int
+        case let int64 as Int64: Int(int64)
+        case let int32 as Int32: Int(int32)
+        case let double as Double: Int(double)
+        case let string as String: Int(string) ?? 0
+        default: 0
+        }
+    }
+
+    private static func doubleValue(from value: Any?) -> Double? {
+        switch value {
+        case let double as Double: double
+        case let int as Int: Double(int)
+        case let int64 as Int64: Double(int64)
+        case let int32 as Int32: Double(int32)
+        case let string as String: Double(string)
+        default: nil
+        }
+    }
+}

--- a/Vapor/Vapor/Services/TurnVectorStore.swift
+++ b/Vapor/Vapor/Services/TurnVectorStore.swift
@@ -134,15 +134,12 @@ struct TurnVectorStore: Sendable {
         guard !trimmed.isEmpty else { return [] }
 
         let queryEmbedding = try await embed(trimmed)
-        let idPrefix: String
         let metadataCount: Int
         let vectorCount: Int
         if let sessionID {
-            idPrefix = "turn:\(sessionID):"
             metadataCount = await turnChunkCount(sessionID: sessionID)
             vectorCount = await turnVectorCount(sessionID: sessionID)
         } else {
-            idPrefix = "turn:"
             let metadataRows = try await database.query("SELECT COUNT(*) AS count FROM \(chunksTableName)")
             let vectorRows = try await database.query("SELECT COUNT(*) AS count FROM \(turnTableName)")
             metadataCount = metadataRows.first?["count"].map(Self.integerValue(from:)) ?? 0
@@ -151,15 +148,30 @@ struct TurnVectorStore: Sendable {
 
         guard vectorCount > 0 else { return [] }
         let searchLimit = min(max(metadataCount, vectorCount, limit * 250, 5_000), max(vectorCount, 1))
-        let rows = try await database.query(
-            "SELECT embedding_id, vec_distance_cosine(embedding, ?) AS distance FROM \(turnTableName) ORDER BY distance ASC LIMIT ?",
-            params: [queryEmbedding, searchLimit]
-        )
+        let rows: [[String: any Sendable]]
+        if let sessionID {
+            rows = try await database.query(
+                """
+                SELECT v.embedding_id, vec_distance_cosine(v.embedding, ?) AS distance
+                FROM \(turnTableName) v
+                JOIN \(chunksTableName) c ON c.embedding_id = v.embedding_id
+                WHERE c.session_id = ?
+                ORDER BY distance ASC
+                LIMIT ?
+                """,
+                params: [queryEmbedding, sessionID, searchLimit]
+            )
+        } else {
+            rows = try await database.query(
+                "SELECT embedding_id, vec_distance_cosine(embedding, ?) AS distance FROM \(turnTableName) ORDER BY distance ASC LIMIT ?",
+                params: [queryEmbedding, searchLimit]
+            )
+        }
 
         var matchingIDs: [String] = []
         var distanceMap: [String: Double] = [:]
         for row in rows {
-            guard let id = row["embedding_id"] as? String, id.hasPrefix(idPrefix) else { continue }
+            guard let id = row["embedding_id"] as? String else { continue }
             guard let distance = Self.doubleValue(from: row["distance"]) else { continue }
             matchingIDs.append(id)
             distanceMap[id] = distance

--- a/Vapor/Vapor/Services/VaporEmbeddedServer.swift
+++ b/Vapor/Vapor/Services/VaporEmbeddedServer.swift
@@ -24,7 +24,9 @@ nonisolated final class VaporEmbeddedServer: @unchecked Sendable {
         onContextCapture: @escaping @Sendable ([String: Any]) -> Void,
         contextItemStatusProvider: @escaping @Sendable (String) -> String?,
         onSessionSearch: @escaping @Sendable () -> (String, String?, Int) async -> [[String: Any]] = { { _, _, _ in [] } },
-        onSessionContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } }
+        onSessionContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } },
+        onAgentIndexStatus: @escaping @Sendable () -> (String?, String?, String?) async -> [String: Any] = { { _, _, _ in ["error": "not_available"] } },
+        onAgentCurrentSession: @escaping @Sendable () -> (String?, String?) async -> [String: Any] = { { _, _ in ["error": "not_available"] } }
     ) async throws {
         let alreadyStarted: Bool = lock.withLock {
             guard _channel == nil else { return true }
@@ -48,7 +50,9 @@ nonisolated final class VaporEmbeddedServer: @unchecked Sendable {
                         onContextCapture: onContextCapture,
                         contextItemStatusProvider: contextItemStatusProvider,
                         onSessionSearch: onSessionSearch,
-                        onSessionContext: onSessionContext
+                        onSessionContext: onSessionContext,
+                        onAgentIndexStatus: onAgentIndexStatus,
+                        onAgentCurrentSession: onAgentCurrentSession
                     )
                     return channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true).flatMap { _ in
                         channel.pipeline.addHandler(handler)

--- a/Vapor/Vapor/Services/VaporEmbeddedServer.swift
+++ b/Vapor/Vapor/Services/VaporEmbeddedServer.swift
@@ -22,7 +22,9 @@ nonisolated final class VaporEmbeddedServer: @unchecked Sendable {
         authTokenProvider: @escaping @Sendable () -> String,
         onResponse: @escaping @Sendable ([String: Any]) -> Void,
         onContextCapture: @escaping @Sendable ([String: Any]) -> Void,
-        contextItemStatusProvider: @escaping @Sendable (String) -> String?
+        contextItemStatusProvider: @escaping @Sendable (String) -> String?,
+        onSessionSearch: @escaping @Sendable () -> (String, String?, Int) async -> [[String: Any]] = { { _, _, _ in [] } },
+        onSessionContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } }
     ) async throws {
         let alreadyStarted: Bool = lock.withLock {
             guard _channel == nil else { return true }
@@ -44,7 +46,9 @@ nonisolated final class VaporEmbeddedServer: @unchecked Sendable {
                         authTokenProvider: authTokenProvider,
                         onExtensionResponse: onResponse,
                         onContextCapture: onContextCapture,
-                        contextItemStatusProvider: contextItemStatusProvider
+                        contextItemStatusProvider: contextItemStatusProvider,
+                        onSessionSearch: onSessionSearch,
+                        onSessionContext: onSessionContext
                     )
                     return channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true).flatMap { _ in
                         channel.pipeline.addHandler(handler)

--- a/Vapor/Vapor/Services/VaporEmbeddedServer.swift
+++ b/Vapor/Vapor/Services/VaporEmbeddedServer.swift
@@ -23,8 +23,8 @@ nonisolated final class VaporEmbeddedServer: @unchecked Sendable {
         onResponse: @escaping @Sendable ([String: Any]) -> Void,
         onContextCapture: @escaping @Sendable ([String: Any]) -> Void,
         contextItemStatusProvider: @escaping @Sendable (String) -> String?,
-        onSessionSearch: @escaping @Sendable () -> (String, String?, Int) async -> [[String: Any]] = { { _, _, _ in [] } },
-        onSessionContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } },
+        onAgentSearch: @escaping @Sendable () -> (String, String?, Int) async -> [[String: Any]] = { { _, _, _ in [] } },
+        onAgentContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } },
         onAgentIndexStatus: @escaping @Sendable () -> (String?, String?, String?) async -> [String: Any] = { { _, _, _ in ["error": "not_available"] } },
         onAgentCurrentSession: @escaping @Sendable () -> (String?, String?) async -> [String: Any] = { { _, _ in ["error": "not_available"] } }
     ) async throws {
@@ -49,8 +49,8 @@ nonisolated final class VaporEmbeddedServer: @unchecked Sendable {
                         onExtensionResponse: onResponse,
                         onContextCapture: onContextCapture,
                         contextItemStatusProvider: contextItemStatusProvider,
-                        onSessionSearch: onSessionSearch,
-                        onSessionContext: onSessionContext,
+                        onAgentSearch: onAgentSearch,
+                        onAgentContext: onAgentContext,
                         onAgentIndexStatus: onAgentIndexStatus,
                         onAgentCurrentSession: onAgentCurrentSession
                     )

--- a/Vapor/Vapor/Services/VaporHTTPHandler.swift
+++ b/Vapor/Vapor/Services/VaporHTTPHandler.swift
@@ -15,8 +15,8 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
     let onExtensionResponse: @Sendable ([String: Any]) -> Void
     let onContextCapture: @Sendable ([String: Any]) -> Void
     let contextItemStatusProvider: @Sendable (String) -> String?
-    let onSessionSearch: @Sendable () -> (String, String?, Int) async -> [[String: Any]]
-    let onSessionContext: @Sendable () -> (String, String, Int, Int) async -> [String: Any]?
+    let onAgentSearch: @Sendable () -> (String, String?, Int) async -> [[String: Any]]
+    let onAgentContext: @Sendable () -> (String, String, Int, Int) async -> [String: Any]?
     let onAgentIndexStatus: @Sendable () -> (String?, String?, String?) async -> [String: Any]
     let onAgentCurrentSession: @Sendable () -> (String?, String?) async -> [String: Any]
 
@@ -31,8 +31,8 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         onExtensionResponse: @escaping @Sendable ([String: Any]) -> Void,
         onContextCapture: @escaping @Sendable ([String: Any]) -> Void,
         contextItemStatusProvider: @escaping @Sendable (String) -> String?,
-        onSessionSearch: @escaping @Sendable () -> (String, String?, Int) async -> [[String: Any]] = { { _, _, _ in [] } },
-        onSessionContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } },
+        onAgentSearch: @escaping @Sendable () -> (String, String?, Int) async -> [[String: Any]] = { { _, _, _ in [] } },
+        onAgentContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } },
         onAgentIndexStatus: @escaping @Sendable () -> (String?, String?, String?) async -> [String: Any] = { { _, _, _ in ["error": "not_available"] } },
         onAgentCurrentSession: @escaping @Sendable () -> (String?, String?) async -> [String: Any] = { { _, _ in ["error": "not_available"] } }
     ) {
@@ -41,8 +41,8 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         self.onExtensionResponse = onExtensionResponse
         self.onContextCapture = onContextCapture
         self.contextItemStatusProvider = contextItemStatusProvider
-        self.onSessionSearch = onSessionSearch
-        self.onSessionContext = onSessionContext
+        self.onAgentSearch = onAgentSearch
+        self.onAgentContext = onAgentContext
         self.onAgentIndexStatus = onAgentIndexStatus
         self.onAgentCurrentSession = onAgentCurrentSession
     }
@@ -95,17 +95,6 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
                     }
                     return
                 }
-                if head.method == .GET, requestPath.hasPrefix("/api/session/") {
-                    let remainder = String(requestPath.dropFirst("/api/session/".count))
-                    if remainder.hasPrefix("search") {
-                        handleSessionSearchGET(context: context, head: head)
-                        return
-                    }
-                    if remainder.contains("/context") {
-                        handleSessionContextGET(context: context, head: head, sessionID: String(remainder.split(separator: "/").first ?? Substring(remainder)))
-                        return
-                    }
-                }
                 if head.method == .GET, requestPath == "/api/agent/index/status" {
                     handleAgentIndexStatusGET(context: context, head: head)
                     return
@@ -115,7 +104,7 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
                     return
                 }
                 if head.method == .GET, requestPath == "/api/agent/search" {
-                    handleSessionSearchGET(context: context, head: head)
+                    handleAgentSearchGET(context: context, head: head)
                     return
                 }
                 if head.method == .GET, requestPath.hasPrefix("/api/agent/sessions/") {
@@ -123,6 +112,10 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
                     let parts = remainder.split(separator: "/").map(String.init)
                     if parts.count == 2, parts[1] == "search" {
                         handleAgentSessionSearchGET(context: context, head: head, sessionID: parts[0])
+                        return
+                    }
+                    if parts.count == 2, parts[1] == "context" {
+                        handleAgentSessionContextGET(context: context, head: head, sessionID: parts[0])
                         return
                     }
                 }
@@ -305,7 +298,7 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         sendJSON(context: context, status: .ok, body: ["status": "accepted", "jobId": jobId])
     }
 
-    private func handleSessionSearchGET(context: ChannelHandlerContext, head: HTTPRequestHead) {
+    private func handleAgentSearchGET(context: ChannelHandlerContext, head: HTTPRequestHead) {
         let queryItems = head.uri.split(separator: "?", maxSplits: 1).last
             .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
         let query = queryItems.first(where: { $0.name == "q" })?.value ?? ""
@@ -319,13 +312,13 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         }
 
         Task {
-            let searchFn = onSessionSearch()
+            let searchFn = onAgentSearch()
             let results = await searchFn(query, sessionID, limit)
             sendJSON(context: context, status: .ok, body: ["results": results, "count": results.count])
         }
     }
 
-    private func handleSessionContextGET(context: ChannelHandlerContext, head: HTTPRequestHead, sessionID: String) {
+    private func handleAgentSessionContextGET(context: ChannelHandlerContext, head: HTTPRequestHead, sessionID: String) {
         let queryItems = head.uri.split(separator: "?", maxSplits: 1).last
             .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
         let query = queryItems.first(where: { $0.name == "q" })?.value ?? ""
@@ -338,7 +331,7 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         }
 
         Task {
-            let contextFn = onSessionContext()
+            let contextFn = onAgentContext()
             if let result = await contextFn(sessionID, query, contextTurns, 5) {
                 sendJSON(context: context, status: .ok, body: result)
             } else {
@@ -360,7 +353,7 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         }
 
         Task {
-            let searchFn = onSessionSearch()
+            let searchFn = onAgentSearch()
             let results = await searchFn(query, sessionID, limit)
             sendJSON(context: context, status: .ok, body: ["results": results, "count": results.count, "session_id": sessionID])
         }

--- a/Vapor/Vapor/Services/VaporHTTPHandler.swift
+++ b/Vapor/Vapor/Services/VaporHTTPHandler.swift
@@ -17,6 +17,8 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
     let contextItemStatusProvider: @Sendable (String) -> String?
     let onSessionSearch: @Sendable () -> (String, String?, Int) async -> [[String: Any]]
     let onSessionContext: @Sendable () -> (String, String, Int, Int) async -> [String: Any]?
+    let onAgentIndexStatus: @Sendable () -> (String?, String?, String?) async -> [String: Any]
+    let onAgentCurrentSession: @Sendable () -> (String?, String?) async -> [String: Any]
 
     private var requestHead: HTTPRequestHead?
     private var requestPath: String = ""
@@ -30,7 +32,9 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         onContextCapture: @escaping @Sendable ([String: Any]) -> Void,
         contextItemStatusProvider: @escaping @Sendable (String) -> String?,
         onSessionSearch: @escaping @Sendable () -> (String, String?, Int) async -> [[String: Any]] = { { _, _, _ in [] } },
-        onSessionContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } }
+        onSessionContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } },
+        onAgentIndexStatus: @escaping @Sendable () -> (String?, String?, String?) async -> [String: Any] = { { _, _, _ in ["error": "not_available"] } },
+        onAgentCurrentSession: @escaping @Sendable () -> (String?, String?) async -> [String: Any] = { { _, _ in ["error": "not_available"] } }
     ) {
         self.sseHub = sseHub
         self.authTokenProvider = authTokenProvider
@@ -39,6 +43,8 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         self.contextItemStatusProvider = contextItemStatusProvider
         self.onSessionSearch = onSessionSearch
         self.onSessionContext = onSessionContext
+        self.onAgentIndexStatus = onAgentIndexStatus
+        self.onAgentCurrentSession = onAgentCurrentSession
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -97,6 +103,26 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
                     }
                     if remainder.contains("/context") {
                         handleSessionContextGET(context: context, head: head, sessionID: String(remainder.split(separator: "/").first ?? Substring(remainder)))
+                        return
+                    }
+                }
+                if head.method == .GET, requestPath == "/api/agent/index/status" {
+                    handleAgentIndexStatusGET(context: context, head: head)
+                    return
+                }
+                if head.method == .GET, requestPath == "/api/agent/current-session" {
+                    handleAgentCurrentSessionGET(context: context, head: head)
+                    return
+                }
+                if head.method == .GET, requestPath == "/api/agent/search" {
+                    handleSessionSearchGET(context: context, head: head)
+                    return
+                }
+                if head.method == .GET, requestPath.hasPrefix("/api/agent/sessions/") {
+                    let remainder = String(requestPath.dropFirst("/api/agent/sessions/".count))
+                    let parts = remainder.split(separator: "/").map(String.init)
+                    if parts.count == 2, parts[1] == "search" {
+                        handleAgentSessionSearchGET(context: context, head: head, sessionID: parts[0])
                         return
                     }
                 }
@@ -318,6 +344,54 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
             } else {
                 sendJSON(context: context, status: .notFound, body: ["error": "No results found"])
             }
+        }
+    }
+
+    private func handleAgentSessionSearchGET(context: ChannelHandlerContext, head: HTTPRequestHead, sessionID: String) {
+        let queryItems = head.uri.split(separator: "?", maxSplits: 1).last
+            .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
+        let query = queryItems.first(where: { $0.name == "q" })?.value ?? ""
+        let limitStr = queryItems.first(where: { $0.name == "limit" })?.value ?? "20"
+        let limit = Int(limitStr) ?? 20
+
+        guard !query.isEmpty else {
+            sendJSON(context: context, status: .badRequest, body: ["error": "Missing 'q' parameter"])
+            return
+        }
+
+        Task {
+            let searchFn = onSessionSearch()
+            let results = await searchFn(query, sessionID, limit)
+            sendJSON(context: context, status: .ok, body: ["results": results, "count": results.count, "session_id": sessionID])
+        }
+    }
+
+    private func handleAgentIndexStatusGET(context: ChannelHandlerContext, head: HTTPRequestHead) {
+        let queryItems = head.uri.split(separator: "?", maxSplits: 1).last
+            .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
+        let sessionID = queryItems.first(where: { $0.name == "session_id" })?.value
+        let cwd = queryItems.first(where: { $0.name == "cwd" })?.value
+        let source = queryItems.first(where: { $0.name == "source" })?.value
+
+        Task {
+            let statusFn = onAgentIndexStatus()
+            let result = await statusFn(sessionID, cwd, source)
+            let hasError = result["error"] != nil
+            sendJSON(context: context, status: hasError ? .notFound : .ok, body: result)
+        }
+    }
+
+    private func handleAgentCurrentSessionGET(context: ChannelHandlerContext, head: HTTPRequestHead) {
+        let queryItems = head.uri.split(separator: "?", maxSplits: 1).last
+            .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
+        let cwd = queryItems.first(where: { $0.name == "cwd" })?.value
+        let source = queryItems.first(where: { $0.name == "source" })?.value
+
+        Task {
+            let currentFn = onAgentCurrentSession()
+            let result = await currentFn(cwd, source)
+            let hasError = result["error"] != nil
+            sendJSON(context: context, status: hasError ? .notFound : .ok, body: result)
         }
     }
 

--- a/Vapor/Vapor/Services/VaporHTTPHandler.swift
+++ b/Vapor/Vapor/Services/VaporHTTPHandler.swift
@@ -15,6 +15,8 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
     let onExtensionResponse: @Sendable ([String: Any]) -> Void
     let onContextCapture: @Sendable ([String: Any]) -> Void
     let contextItemStatusProvider: @Sendable (String) -> String?
+    let onSessionSearch: @Sendable () -> (String, String?, Int) async -> [[String: Any]]
+    let onSessionContext: @Sendable () -> (String, String, Int, Int) async -> [String: Any]?
 
     private var requestHead: HTTPRequestHead?
     private var requestPath: String = ""
@@ -26,13 +28,17 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         authTokenProvider: @escaping @Sendable () -> String,
         onExtensionResponse: @escaping @Sendable ([String: Any]) -> Void,
         onContextCapture: @escaping @Sendable ([String: Any]) -> Void,
-        contextItemStatusProvider: @escaping @Sendable (String) -> String?
+        contextItemStatusProvider: @escaping @Sendable (String) -> String?,
+        onSessionSearch: @escaping @Sendable () -> (String, String?, Int) async -> [[String: Any]] = { { _, _, _ in [] } },
+        onSessionContext: @escaping @Sendable () -> (String, String, Int, Int) async -> [String: Any]? = { { _, _, _, _ in nil } }
     ) {
         self.sseHub = sseHub
         self.authTokenProvider = authTokenProvider
         self.onExtensionResponse = onExtensionResponse
         self.onContextCapture = onContextCapture
         self.contextItemStatusProvider = contextItemStatusProvider
+        self.onSessionSearch = onSessionSearch
+        self.onSessionContext = onSessionContext
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -58,7 +64,8 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
                 sendJSON(context: context, status: .ok, body: [
                     "status": "ok",
                     "version": "1.0",
-                    "connectedClients": sseHub.clientCount
+                    "connectedClients": sseHub.clientCount,
+                    "authEnabled": !authTokenProvider().isEmpty
                 ])
                 return
             }
@@ -81,6 +88,17 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
                         sendJSON(context: context, status: .notFound, body: ["error": "Not found"])
                     }
                     return
+                }
+                if head.method == .GET, requestPath.hasPrefix("/api/session/") {
+                    let remainder = String(requestPath.dropFirst("/api/session/".count))
+                    if remainder.hasPrefix("search") {
+                        handleSessionSearchGET(context: context, head: head)
+                        return
+                    }
+                    if remainder.contains("/context") {
+                        handleSessionContextGET(context: context, head: head, sessionID: String(remainder.split(separator: "/").first ?? Substring(remainder)))
+                        return
+                    }
                 }
                 sendJSON(context: context, status: .notFound, body: ["error": "Not found"])
             }
@@ -259,6 +277,48 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         onContextCapture(json)
         let jobId = json["jobId"] as? String ?? "unknown"
         sendJSON(context: context, status: .ok, body: ["status": "accepted", "jobId": jobId])
+    }
+
+    private func handleSessionSearchGET(context: ChannelHandlerContext, head: HTTPRequestHead) {
+        let queryItems = head.uri.split(separator: "?", maxSplits: 1).last
+            .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
+        let query = queryItems.first(where: { $0.name == "q" })?.value ?? ""
+        let sessionID = queryItems.first(where: { $0.name == "session_id" })?.value
+        let limitStr = queryItems.first(where: { $0.name == "limit" })?.value ?? "20"
+        let limit = Int(limitStr) ?? 20
+
+        guard !query.isEmpty else {
+            sendJSON(context: context, status: .badRequest, body: ["error": "Missing 'q' parameter"])
+            return
+        }
+
+        Task {
+            let searchFn = onSessionSearch()
+            let results = await searchFn(query, sessionID, limit)
+            sendJSON(context: context, status: .ok, body: ["results": results, "count": results.count])
+        }
+    }
+
+    private func handleSessionContextGET(context: ChannelHandlerContext, head: HTTPRequestHead, sessionID: String) {
+        let queryItems = head.uri.split(separator: "?", maxSplits: 1).last
+            .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
+        let query = queryItems.first(where: { $0.name == "q" })?.value ?? ""
+        let contextTurnsStr = queryItems.first(where: { $0.name == "context_turns" })?.value ?? "2"
+        let contextTurns = Int(contextTurnsStr) ?? 2
+
+        guard !query.isEmpty else {
+            sendJSON(context: context, status: .badRequest, body: ["error": "Missing 'q' parameter"])
+            return
+        }
+
+        Task {
+            let contextFn = onSessionContext()
+            if let result = await contextFn(sessionID, query, contextTurns, 5) {
+                sendJSON(context: context, status: .ok, body: result)
+            } else {
+                sendJSON(context: context, status: .notFound, body: ["error": "No results found"])
+            }
+        }
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {

--- a/Vapor/Vapor/Services/VaporHTTPHandler.swift
+++ b/Vapor/Vapor/Services/VaporHTTPHandler.swift
@@ -303,8 +303,10 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
             .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
         let query = queryItems.first(where: { $0.name == "q" })?.value ?? ""
         let sessionID = queryItems.first(where: { $0.name == "session_id" })?.value
-        let limitStr = queryItems.first(where: { $0.name == "limit" })?.value ?? "20"
-        let limit = Int(limitStr) ?? 20
+        guard let limit = positiveIntQuery(queryItems, name: "limit", defaultValue: 20, maxValue: 100) else {
+            sendJSON(context: context, status: .badRequest, body: ["error": "Invalid 'limit' parameter"])
+            return
+        }
 
         guard !query.isEmpty else {
             sendJSON(context: context, status: .badRequest, body: ["error": "Missing 'q' parameter"])
@@ -322,8 +324,11 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         let queryItems = head.uri.split(separator: "?", maxSplits: 1).last
             .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
         let query = queryItems.first(where: { $0.name == "q" })?.value ?? ""
-        let contextTurnsStr = queryItems.first(where: { $0.name == "context_turns" })?.value ?? "2"
-        let contextTurns = Int(contextTurnsStr) ?? 2
+        guard let contextTurns = positiveIntQuery(queryItems, name: "context_turns", defaultValue: 2, maxValue: 10),
+              let limit = positiveIntQuery(queryItems, name: "limit", defaultValue: 5, maxValue: 100) else {
+            sendJSON(context: context, status: .badRequest, body: ["error": "Invalid context query parameter"])
+            return
+        }
 
         guard !query.isEmpty else {
             sendJSON(context: context, status: .badRequest, body: ["error": "Missing 'q' parameter"])
@@ -332,7 +337,7 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
 
         Task {
             let contextFn = onAgentContext()
-            if let result = await contextFn(sessionID, query, contextTurns, 5) {
+            if let result = await contextFn(sessionID, query, contextTurns, limit) {
                 sendJSON(context: context, status: .ok, body: result)
             } else {
                 sendJSON(context: context, status: .notFound, body: ["error": "No results found"])
@@ -344,8 +349,10 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
         let queryItems = head.uri.split(separator: "?", maxSplits: 1).last
             .flatMap { URLComponents(string: "?\($0)") }?.queryItems ?? []
         let query = queryItems.first(where: { $0.name == "q" })?.value ?? ""
-        let limitStr = queryItems.first(where: { $0.name == "limit" })?.value ?? "20"
-        let limit = Int(limitStr) ?? 20
+        guard let limit = positiveIntQuery(queryItems, name: "limit", defaultValue: 20, maxValue: 100) else {
+            sendJSON(context: context, status: .badRequest, body: ["error": "Invalid 'limit' parameter"])
+            return
+        }
 
         guard !query.isEmpty else {
             sendJSON(context: context, status: .badRequest, body: ["error": "Missing 'q' parameter"])
@@ -386,6 +393,14 @@ nonisolated final class VaporHTTPHandler: ChannelInboundHandler, @unchecked Send
             let hasError = result["error"] != nil
             sendJSON(context: context, status: hasError ? .notFound : .ok, body: result)
         }
+    }
+
+    private func positiveIntQuery(_ queryItems: [URLQueryItem], name: String, defaultValue: Int, maxValue: Int) -> Int? {
+        guard let raw = queryItems.first(where: { $0.name == name })?.value else {
+            return defaultValue
+        }
+        guard let value = Int(raw), value > 0 else { return nil }
+        return min(value, maxValue)
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {

--- a/Vapor/Vapor/Services/VectorizationService.swift
+++ b/Vapor/Vapor/Services/VectorizationService.swift
@@ -12,11 +12,14 @@ nonisolated(unsafe) private var sharedVectorDatabase: Database?
 final class VectorizationService {
     static let shared = VectorizationService()
 
-    private static let tableName = "vec_items_minilm_l12_multilingual_v2"
+    private static let tableName = "vec_items_minilm_l6_v2"
+    private static let turnTableName = "vec_turn_chunks_minilm_l6_v2"
+    private static let turnChunksTableName = "turn_chunks"
     private static let contextEmbeddingPrefix = "ctx:"
     private static let promptEmbeddingPrefix = "prompt:"
+    private static let turnEmbeddingPrefix = "turn:"
 
-    private let embeddingService = MiniLMEmbeddingService()
+    nonisolated(unsafe) private let embeddingService = MiniLMEmbeddingService()
 
     private(set) var isInitializing = false
     private(set) var isReady = false
@@ -26,7 +29,7 @@ final class VectorizationService {
     private init() {}
 
     var providerDisplayName: String {
-        "MiniLM paraphrase-multilingual-L12-v2"
+        "MiniLM all-MiniLM-L6-v2"
     }
 
     func initialize() async {
@@ -122,6 +125,250 @@ final class VectorizationService {
         } catch {
             vectorLogger.error("Failed to delete embedding \(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             lastError = error.localizedDescription
+        }
+    }
+
+    func storeEmbedding(embeddingID: String, text: String) async throws {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let embedding = try await generateEmbedding(for: trimmed)
+        try await upsert(embedding: embedding, id: embeddingID)
+    }
+
+    func removeTurnEmbeddings(turnSourceID: String) async {
+        let database = try? await Self.sharedDatabase()
+        guard let database else { return }
+        let pattern = "%:\(turnSourceID):%"
+        do {
+            let rows = try await database.query(
+                "SELECT embedding_id FROM \(Self.turnTableName) WHERE embedding_id LIKE ?",
+                params: [pattern]
+            )
+            for row in rows {
+                if let id = row["embedding_id"] as? String {
+                    try await database.execute("DELETE FROM \(Self.turnTableName) WHERE embedding_id = ?", params: [id])
+                    try await database.execute("DELETE FROM \(Self.tableName) WHERE embedding_id = ?", params: [id])
+                    try await database.execute("DELETE FROM \(Self.turnChunksTableName) WHERE embedding_id = ?", params: [id])
+                }
+            }
+            await refreshVectorCount()
+        } catch {
+            vectorLogger.error("Failed to remove turn embeddings for \(turnSourceID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func storeTurnChunk(embeddingID: String, text: String, turnSourceID: String, sessionID: String, chunkIndex: Int) async throws {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let embedding = try await generateEmbedding(for: trimmed)
+        let database = try await Self.sharedDatabase()
+        try await Self.upsertTurn(embedding: embedding, id: embeddingID, database: database)
+
+        try await database.execute(
+            "INSERT OR REPLACE INTO \(Self.turnChunksTableName) (embedding_id, chunk_text, turn_source_id, session_id, chunk_index) VALUES (?, ?, ?, ?, ?)",
+            params: [embeddingID, trimmed, turnSourceID, sessionID, chunkIndex]
+        )
+    }
+
+    nonisolated func hasTurnChunks(turnSourceID: String) async -> Bool {
+        do {
+            let database = try await Self.sharedDatabase()
+            let rows = try await database.query(
+                "SELECT COUNT(*) AS count FROM \(Self.turnChunksTableName) WHERE turn_source_id = ?",
+                params: [turnSourceID]
+            )
+            if let count = rows.first?["count"] {
+                return Self.integerValue(from: count) > 0
+            }
+            return false
+        } catch {
+            return false
+        }
+    }
+
+    nonisolated func hasTurnVectors(turnSourceID: String) async -> Bool {
+        do {
+            let database = try await Self.sharedDatabase()
+            return await turnStore(database: database).hasTurnVectors(turnSourceID: turnSourceID)
+        } catch {
+            return false
+        }
+    }
+
+    nonisolated func clearTurnVectors(sessionID: String) async throws {
+        let database = try await Self.sharedDatabase()
+        let rows = try await database.query(
+            "SELECT embedding_id FROM \(Self.turnTableName) WHERE embedding_id LIKE ?",
+            params: ["\(Self.turnEmbeddingPrefix)\(sessionID):%"]
+        )
+        for row in rows {
+            if let id = row["embedding_id"] as? String {
+                try await database.execute("DELETE FROM \(Self.turnTableName) WHERE embedding_id = ?", params: [id])
+            }
+        }
+    }
+
+    nonisolated func embedAndStoreBatch(
+        chunks: [(embeddingID: String, text: String, turnSourceID: String, sessionID: String, chunkIndex: Int)]
+    ) async throws -> Int {
+        let database = try await Self.sharedDatabase()
+        let vectorChunks = chunks.map {
+            TurnVectorChunk(
+                embeddingID: $0.embeddingID,
+                text: $0.text,
+                turnSourceID: $0.turnSourceID,
+                sessionID: $0.sessionID,
+                chunkIndex: $0.chunkIndex
+            )
+        }
+        return try await turnStore(database: database).embedAndStore(vectorChunks)
+    }
+
+    func searchTurnChunks(matching query: String, sessionID: String? = nil, limit: Int = 20) async -> [[String: Any]] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        await initialize()
+        guard isReady else { return [] }
+
+        do {
+            let startedAt = CFAbsoluteTimeGetCurrent()
+            let embedding = try await generateEmbedding(for: trimmed)
+            let database = try await Self.sharedDatabase()
+
+            let prefixFilter: String
+            var metadataCount = 0
+            var vectorCount = 0
+            if let sessionID {
+                prefixFilter = "turn:\(sessionID):%"
+                metadataCount = await turnChunkCount(sessionID: sessionID)
+                vectorCount = await turnVectorCount(sessionID: sessionID)
+            } else {
+                prefixFilter = "turn:%"
+                let metadataRows = try await database.query("SELECT COUNT(*) AS count FROM \(Self.turnChunksTableName)")
+                let vectorRows = try await database.query("SELECT COUNT(*) AS count FROM \(Self.turnTableName)")
+                metadataCount = metadataRows.first?["count"].map(Self.integerValue(from:)) ?? 0
+                vectorCount = vectorRows.first?["count"].map(Self.integerValue(from:)) ?? 0
+            }
+            let searchLimit = min(max(metadataCount, vectorCount, limit * 250, 5_000), max(vectorCount, 1))
+
+            let sql = "SELECT embedding_id, vec_distance_cosine(embedding, ?) AS distance FROM \(Self.turnTableName) ORDER BY distance ASC LIMIT ?"
+            vectorLogger.debug("Turn chunk search SQL: \(sql, privacy: .public)")
+            vectorLogger.info("Turn chunk search start: prefix=\(prefixFilter.prefix(60), privacy: .public), embedding_dims=\(embedding.count), k=\(searchLimit), metadata=\(metadataCount), vectors=\(vectorCount), query=\(trimmed.prefix(80), privacy: .public)")
+
+            guard vectorCount > 0 else {
+                vectorLogger.warning("Turn chunk search skipped: no turn vectors available for prefix \(prefixFilter.prefix(60), privacy: .public)")
+                return []
+            }
+
+            let knnRows = try await database.query(sql, params: [embedding, searchLimit])
+
+            guard !knnRows.isEmpty else {
+                vectorLogger.info("Turn chunk search complete: raw=0 filtered=0 elapsed=\(String(format: "%.3f", CFAbsoluteTimeGetCurrent() - startedAt))s")
+                return []
+            }
+
+            var matchingIDs: [String] = []
+            var distanceMap: [String: Double] = [:]
+            for row in knnRows {
+                guard let id = row["embedding_id"] as? String, id.hasPrefix(prefixFilter.dropLast()) else { continue }
+                let dist: Double
+                if let distanceVal = row["distance"] as? Double {
+                    dist = distanceVal
+                } else if let distanceVal = row["distance"] as? Int {
+                    dist = Double(distanceVal)
+                } else {
+                    continue
+                }
+                matchingIDs.append(id)
+                distanceMap[id] = dist
+                if matchingIDs.count >= limit { break }
+            }
+
+            guard !matchingIDs.isEmpty else {
+                vectorLogger.info("Turn chunk search complete: raw=\(knnRows.count) filtered=0 elapsed=\(String(format: "%.3f", CFAbsoluteTimeGetCurrent() - startedAt))s")
+                return []
+            }
+
+            let placeholders = matchingIDs.map { _ in "?" }.joined(separator: ",")
+            let chunkRows = try await database.query(
+                "SELECT embedding_id, chunk_text, turn_source_id, session_id, chunk_index FROM \(Self.turnChunksTableName) WHERE embedding_id IN (\(placeholders))",
+                params: matchingIDs
+            )
+
+            let results: [[String: Any]] = chunkRows.compactMap { row in
+                guard let embeddingID = row["embedding_id"] as? String,
+                      let distance = distanceMap[embeddingID] else { return nil }
+                return [
+                    "embedding_id": embeddingID,
+                    "distance": distance,
+                    "chunk_text": row["chunk_text"] as? String ?? "",
+                    "turn_source_id": row["turn_source_id"] as? String ?? "",
+                    "session_id": row["session_id"] as? String ?? "",
+                    "chunk_index": row["chunk_index"] ?? 0
+                ] as [String: Any]
+            }
+            .sorted { left, right in
+                let leftDistance = left["distance"] as? Double ?? .greatestFiniteMagnitude
+                let rightDistance = right["distance"] as? Double ?? .greatestFiniteMagnitude
+                return leftDistance < rightDistance
+            }
+
+            vectorLogger.info("Turn chunk search complete: raw=\(knnRows.count), filtered=\(matchingIDs.count), metadataRows=\(chunkRows.count), results=\(results.count), elapsed=\(String(format: "%.3f", CFAbsoluteTimeGetCurrent() - startedAt))s")
+            return results
+        } catch {
+            vectorLogger.error("Turn chunk search failed: \(error.localizedDescription, privacy: .public)")
+            lastError = error.localizedDescription
+            return []
+        }
+    }
+
+    func fetchChunkTexts(turnSourceID: String) async -> [[String: Any]] {
+        do {
+            let database = try await Self.sharedDatabase()
+            return try await database.query(
+                "SELECT embedding_id, chunk_text, turn_source_id, session_id, chunk_index FROM \(Self.turnChunksTableName) WHERE turn_source_id = ? ORDER BY chunk_index ASC",
+                params: [turnSourceID]
+            )
+        } catch {
+            vectorLogger.error("Failed to fetch chunk texts: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+    }
+
+    func turnChunkCount(sessionID: String) async -> Int {
+        do {
+            let database = try await Self.sharedDatabase()
+            let rows = try await database.query(
+                "SELECT COUNT(*) AS count FROM \(Self.turnChunksTableName) WHERE session_id = ?",
+                params: [sessionID]
+            )
+            if let count = rows.first?["count"] {
+                return Self.integerValue(from: count)
+            }
+            return 0
+        } catch {
+            vectorLogger.error("Failed to count turn chunks: \(error.localizedDescription, privacy: .public)")
+            return 0
+        }
+    }
+
+    func turnVectorCount(sessionID: String) async -> Int {
+        do {
+            let database = try await Self.sharedDatabase()
+            let rows = try await database.query(
+                "SELECT COUNT(*) AS count FROM \(Self.turnTableName) WHERE embedding_id LIKE ?",
+                params: ["\(Self.turnEmbeddingPrefix)\(sessionID):%"]
+            )
+            if let count = rows.first?["count"] {
+                return Self.integerValue(from: count)
+            }
+            return 0
+        } catch {
+            vectorLogger.error("Failed to count turn vectors: \(error.localizedDescription, privacy: .public)")
+            return 0
         }
     }
 
@@ -290,6 +537,14 @@ final class VectorizationService {
         }
     }
 
+    nonisolated private static func upsertTurn(embedding: [Float], id: String, database: Database) async throws {
+        try await database.execute("DELETE FROM \(turnTableName) WHERE embedding_id = ?", params: [id])
+        try await database.execute(
+            "INSERT INTO \(turnTableName)(embedding, embedding_id) VALUES (?, ?)",
+            params: [embedding, id]
+        )
+    }
+
     private func embeddingExists(id: String) async throws -> Bool {
         let database = try await Self.sharedDatabase()
         for candidateID in Self.candidateEmbeddingIDs(for: id) {
@@ -330,6 +585,18 @@ final class VectorizationService {
 
         let joined = segments.joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
         return joined.isEmpty ? nil : joined
+    }
+
+    nonisolated private func turnStore(database: Database) -> TurnVectorStore {
+        TurnVectorStore(
+            database: database,
+            turnTableName: Self.turnTableName,
+            chunksTableName: Self.turnChunksTableName,
+            dimensions: MiniLMEmbeddingService.dimensions,
+            embed: { [embeddingService] text in
+                try await embeddingService.embed(text: text)
+            }
+        )
     }
 
     private static func sharedDatabase() async throws -> Database {
@@ -388,6 +655,48 @@ final class VectorizationService {
                 "CREATE VIRTUAL TABLE \(tableName) USING vec0(embedding float[\(MiniLMEmbeddingService.dimensions)], embedding_id TEXT)"
             )
         }
+
+        do {
+            let tableInfo = try await database.query("PRAGMA table_info(\(turnTableName))")
+            if tableInfo.isEmpty {
+                try await database.execute(
+                    "CREATE VIRTUAL TABLE \(turnTableName) USING vec0(embedding float[\(MiniLMEmbeddingService.dimensions)], embedding_id TEXT)"
+                )
+            }
+        } catch {
+            try await database.execute(
+                "CREATE VIRTUAL TABLE \(turnTableName) USING vec0(embedding float[\(MiniLMEmbeddingService.dimensions)], embedding_id TEXT)"
+            )
+        }
+
+        do {
+            let tableInfo = try await database.query("PRAGMA table_info(\(turnChunksTableName))")
+            if tableInfo.isEmpty {
+                try await database.execute(
+                    """
+                    CREATE TABLE \(turnChunksTableName) (
+                        embedding_id TEXT PRIMARY KEY,
+                        chunk_text TEXT NOT NULL,
+                        turn_source_id TEXT NOT NULL,
+                        session_id TEXT NOT NULL,
+                        chunk_index INTEGER NOT NULL
+                    )
+                    """
+                )
+            }
+        } catch {
+            try await database.execute(
+                """
+                CREATE TABLE \(turnChunksTableName) (
+                    embedding_id TEXT PRIMARY KEY,
+                    chunk_text TEXT NOT NULL,
+                    turn_source_id TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    chunk_index INTEGER NOT NULL
+                )
+                """
+            )
+        }
     }
 
     nonisolated private static func vectorDatabaseDirectory() throws -> URL {
@@ -397,7 +706,7 @@ final class VectorizationService {
         return appSupportURL.appendingPathComponent("Vapor", isDirectory: true)
     }
 
-    private static func integerValue(from value: Any) -> Int {
+    nonisolated private static func integerValue(from value: Any) -> Int {
         switch value {
         case let int as Int: int
         case let int64 as Int64: Int(int64)

--- a/Vapor/Vapor/Services/VectorizationService.swift
+++ b/Vapor/Vapor/Services/VectorizationService.swift
@@ -208,6 +208,7 @@ final class VectorizationService {
                 try await database.execute("DELETE FROM \(Self.turnTableName) WHERE embedding_id = ?", params: [id])
             }
         }
+        try await database.execute("DELETE FROM \(Self.turnChunksTableName) WHERE session_id = ?", params: [sessionID])
     }
 
     nonisolated func embedAndStoreBatch(
@@ -235,88 +236,39 @@ final class VectorizationService {
 
         do {
             let startedAt = CFAbsoluteTimeGetCurrent()
-            let embedding = try await generateEmbedding(for: trimmed)
             let database = try await Self.sharedDatabase()
-
-            let prefixFilter: String
-            var metadataCount = 0
-            var vectorCount = 0
+            let store = turnStore(database: database)
+            let metadataCount: Int
+            let vectorCount: Int
             if let sessionID {
-                prefixFilter = "turn:\(sessionID):%"
-                metadataCount = await turnChunkCount(sessionID: sessionID)
-                vectorCount = await turnVectorCount(sessionID: sessionID)
+                metadataCount = await store.turnChunkCount(sessionID: sessionID)
+                vectorCount = await store.turnVectorCount(sessionID: sessionID)
             } else {
-                prefixFilter = "turn:%"
                 let metadataRows = try await database.query("SELECT COUNT(*) AS count FROM \(Self.turnChunksTableName)")
                 let vectorRows = try await database.query("SELECT COUNT(*) AS count FROM \(Self.turnTableName)")
                 metadataCount = metadataRows.first?["count"].map(Self.integerValue(from:)) ?? 0
                 vectorCount = vectorRows.first?["count"].map(Self.integerValue(from:)) ?? 0
             }
-            let searchLimit = min(max(metadataCount, vectorCount, limit * 250, 5_000), max(vectorCount, 1))
-
-            let sql = "SELECT embedding_id, vec_distance_cosine(embedding, ?) AS distance FROM \(Self.turnTableName) ORDER BY distance ASC LIMIT ?"
-            vectorLogger.debug("Turn chunk search SQL: \(sql, privacy: .public)")
-            vectorLogger.info("Turn chunk search start: prefix=\(prefixFilter.prefix(60), privacy: .public), embedding_dims=\(embedding.count), k=\(searchLimit), metadata=\(metadataCount), vectors=\(vectorCount), query=\(trimmed.prefix(80), privacy: .public)")
+            vectorLogger.info("Turn chunk search start: session=\(sessionID ?? "all", privacy: .public), metadata=\(metadataCount), vectors=\(vectorCount), query=\(trimmed.prefix(80), privacy: .public)")
 
             guard vectorCount > 0 else {
-                vectorLogger.warning("Turn chunk search skipped: no turn vectors available for prefix \(prefixFilter.prefix(60), privacy: .public)")
+                vectorLogger.warning("Turn chunk search skipped: no turn vectors available")
                 return []
             }
 
-            let knnRows = try await database.query(sql, params: [embedding, searchLimit])
-
-            guard !knnRows.isEmpty else {
-                vectorLogger.info("Turn chunk search complete: raw=0 filtered=0 elapsed=\(String(format: "%.3f", CFAbsoluteTimeGetCurrent() - startedAt))s")
-                return []
-            }
-
-            var matchingIDs: [String] = []
-            var distanceMap: [String: Double] = [:]
-            for row in knnRows {
-                guard let id = row["embedding_id"] as? String, id.hasPrefix(prefixFilter.dropLast()) else { continue }
-                let dist: Double
-                if let distanceVal = row["distance"] as? Double {
-                    dist = distanceVal
-                } else if let distanceVal = row["distance"] as? Int {
-                    dist = Double(distanceVal)
-                } else {
-                    continue
-                }
-                matchingIDs.append(id)
-                distanceMap[id] = dist
-                if matchingIDs.count >= limit { break }
-            }
-
-            guard !matchingIDs.isEmpty else {
-                vectorLogger.info("Turn chunk search complete: raw=\(knnRows.count) filtered=0 elapsed=\(String(format: "%.3f", CFAbsoluteTimeGetCurrent() - startedAt))s")
-                return []
-            }
-
-            let placeholders = matchingIDs.map { _ in "?" }.joined(separator: ",")
-            let chunkRows = try await database.query(
-                "SELECT embedding_id, chunk_text, turn_source_id, session_id, chunk_index FROM \(Self.turnChunksTableName) WHERE embedding_id IN (\(placeholders))",
-                params: matchingIDs
-            )
-
-            let results: [[String: Any]] = chunkRows.compactMap { row in
-                guard let embeddingID = row["embedding_id"] as? String,
-                      let distance = distanceMap[embeddingID] else { return nil }
+            let matches = try await store.search(matching: trimmed, sessionID: sessionID, limit: limit)
+            let results: [[String: Any]] = matches.map { match in
                 return [
-                    "embedding_id": embeddingID,
-                    "distance": distance,
-                    "chunk_text": row["chunk_text"] as? String ?? "",
-                    "turn_source_id": row["turn_source_id"] as? String ?? "",
-                    "session_id": row["session_id"] as? String ?? "",
-                    "chunk_index": row["chunk_index"] ?? 0
+                    "embedding_id": match.embeddingID,
+                    "distance": match.distance,
+                    "chunk_text": match.chunkText,
+                    "turn_source_id": match.turnSourceID,
+                    "session_id": match.sessionID,
+                    "chunk_index": match.chunkIndex
                 ] as [String: Any]
             }
-            .sorted { left, right in
-                let leftDistance = left["distance"] as? Double ?? .greatestFiniteMagnitude
-                let rightDistance = right["distance"] as? Double ?? .greatestFiniteMagnitude
-                return leftDistance < rightDistance
-            }
 
-            vectorLogger.info("Turn chunk search complete: raw=\(knnRows.count), filtered=\(matchingIDs.count), metadataRows=\(chunkRows.count), results=\(results.count), elapsed=\(String(format: "%.3f", CFAbsoluteTimeGetCurrent() - startedAt))s")
+            vectorLogger.info("Turn chunk search complete: results=\(results.count), elapsed=\(String(format: "%.3f", CFAbsoluteTimeGetCurrent() - startedAt))s")
             return results
         } catch {
             vectorLogger.error("Turn chunk search failed: \(error.localizedDescription, privacy: .public)")

--- a/Vapor/Vapor/VaporApp.swift
+++ b/Vapor/Vapor/VaporApp.swift
@@ -155,14 +155,17 @@ struct VaporApp: App {
         .modelContainer(sharedModelContainer)
         .environment(contextExplorerStore)
         .windowStyle(.titleBar)
-        .defaultSize(width: 560, height: 600)
+        .defaultSize(width: 940, height: 720)
 
-        WindowGroup("Context Explorer", id: "context-explorer") {
-            ContextExplorerView()
-                .environment(contextExplorerStore)
-                .environment(vectorizationService)
+        WindowGroup("Agent Session", for: AgentSessionPayload.self) { $payload in
+            Group {
+                if let payload, let sourceID = $payload.wrappedValue?.sourceID {
+                    OpenCodeSessionWindowView(sourceID: sourceID)
+                }
+            }
         }
         .modelContainer(sharedModelContainer)
+        .environment(vectorizationService)
         .windowStyle(.titleBar)
         .defaultSize(width: 940, height: 720)
 
@@ -187,12 +190,16 @@ struct VaporApp: App {
                 .environment(StatusBarService.shared)
                 .onAppear {
                     browserBridge.setContextQueueService(contextQueueService)
+                    browserBridge.setVectorizationService(vectorizationService)
                     contextQueueService.setModelContext(sharedModelContainer.mainContext)
+                    OpenCodeSessionIndexer.shared.setModelContainer(sharedModelContainer)
                     screenshotShelfStore.setModelContext(sharedModelContainer.mainContext)
                     screenshotShelfStore.setContextQueueService(contextQueueService)
                     screenshotShelfStore.setMaxImageDimension(preferences.maxImageDimension.rawValue)
                     screenshotShelfStore.start()
-                    Task { @MainActor in await vectorizationService.initialize() }
+                    Task { @MainActor in
+                        await vectorizationService.initialize()
+                    }
                     setupBrowserBridge()
                     KeyboardShortcuts.onKeyUp(for: .toggleVapor) { windowManager.focus() }
                     windowManager.setupWindowOnAppear()

--- a/Vapor/Vapor/Views/ContextTrayView.swift
+++ b/Vapor/Vapor/Views/ContextTrayView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftData
 
 struct ContextTrayView: View {
     @Environment(ContextQueueService.self) private var contextQueue
@@ -8,6 +9,44 @@ struct ContextTrayView: View {
     @State private var searchText = ""
     @State private var showReadyOnly = false
     @State private var selectedItemID: UUID?
+
+    @State private var browserExpanded = false
+    @State private var agentSectionExpanded = false
+    @State private var selectedDirectory: String?
+
+    @State private var sessions: [OpenCodeSession] = []
+    @State private var directories: [(directory: String, sessionCount: Int)] = []
+    @State private var totalSessionCount: Int = 0
+    @State private var isLoadingSessions = false
+    @State private var sessionSearchText = ""
+
+    private var reader: OpenCodeReader { .shared }
+
+    private var hasOpenCodeDB: Bool {
+        reader.isAvailable
+    }
+
+    private var hasConversations: Bool {
+        hasOpenCodeDB
+    }
+
+    private var filteredSessions: [OpenCodeSession] {
+        var result = sessions
+
+        if let directory = selectedDirectory {
+            result = result.filter { $0.directory == directory }
+        }
+
+        if !sessionSearchText.isEmpty {
+            let query = sessionSearchText.lowercased()
+            result = result.filter {
+                $0.title.lowercased().contains(query) ||
+                $0.directory.lowercased().contains(query)
+            }
+        }
+
+        return result
+    }
 
     private var filteredItems: [ContextItem] {
         var items = showReadyOnly ? contextQueue.ready : contextQueue.ready + contextQueue.queue + contextQueue.processing + contextQueue.failed
@@ -24,18 +63,50 @@ struct ContextTrayView: View {
     var body: some View {
         VStack(spacing: 0) {
             headerBar
-
             Divider()
 
-            searchBar
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    browserSection
+                    if hasConversations {
+                        agentSection
+                    }
+                }
+                .padding(.vertical, 2)
+            }
 
             Divider()
+            footerBar
+        }
+        .frame(width: 248)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
 
-            if filteredItems.isEmpty {
-                emptyState
-            } else {
-                ScrollViewReader { proxy in
-                    ScrollView {
+    // MARK: - Captured Section
+
+    @ViewBuilder
+    private var browserSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionHeader(
+                title: "Browser",
+                systemImage: "safari",
+                badge: contextQueue.ready.count,
+                isExpanded: browserExpanded,
+                onTap: {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        browserExpanded.toggle()
+                    }
+                }
+            )
+            .padding(.horizontal, 8)
+
+            if browserExpanded {
+                searchBar
+
+                if filteredItems.isEmpty {
+                    emptyState
+                } else {
+                    ScrollViewReader { proxy in
                         LazyVStack(alignment: .leading, spacing: 2) {
                             ForEach(filteredItems) { item in
                                 Button {
@@ -68,22 +139,16 @@ struct ContextTrayView: View {
                             }
                         }
                         .padding(.vertical, 4)
-                    }
-                    .onChange(of: selectedItemID) { _, id in
-                        guard focusStore.activeZone == .contextTray, let id else { return }
-                        withAnimation(.easeInOut(duration: 0.12)) {
-                            proxy.scrollTo(id, anchor: .center)
+                        .onChange(of: selectedItemID) { _, id in
+                            guard focusStore.activeZone == .contextTray, let id else { return }
+                            withAnimation(.easeInOut(duration: 0.12)) {
+                                proxy.scrollTo(id, anchor: .center)
+                            }
                         }
                     }
                 }
             }
-
-            Divider()
-
-            footerBar
         }
-        .frame(width: 248)
-        .background(Color(nsColor: .windowBackgroundColor))
         .onReceive(NotificationCenter.default.publisher(for: .vaporFocusContextTray)) { _ in
             focusStore.focus(.contextTray)
             if selectedItemID == nil {
@@ -128,24 +193,243 @@ struct ContextTrayView: View {
         }
     }
 
+    // MARK: - Agent Sessions Section
+
+    @ViewBuilder
+    private var agentSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    agentSectionExpanded.toggle()
+                }
+                if agentSectionExpanded && sessions.isEmpty && !isLoadingSessions {
+                    loadSessionData()
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: agentSectionExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 12)
+
+                    Image(systemName: "terminal")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+
+                    Text("Sessions")
+                        .font(.system(size: 12, weight: .semibold))
+
+                    Spacer()
+
+                    if totalSessionCount > 0 {
+                        Text("\(totalSessionCount)")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(Color.secondary.opacity(0.1)))
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.vertical, 6)
+            .padding(.horizontal, 8)
+
+            if agentSectionExpanded {
+                if isLoadingSessions {
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .scaleEffect(0.5)
+                        Text("Loading sessions...")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                } else {
+                    sessionListView
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var sessionListView: some View {
+        Group {
+            if filteredSessions.isEmpty {
+                VStack(spacing: 6) {
+                    Spacer()
+                    Image(systemName: "terminal")
+                        .font(.system(size: 22))
+                        .foregroundStyle(.secondary.opacity(0.4))
+                    Text(sessionSearchText.isEmpty ? "No sessions found" : "No matching sessions")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+            } else {
+                sessionSearchField
+
+                if directories.count > 1 {
+                    directoryFilterBar
+                    Divider()
+                }
+
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    ForEach(filteredSessions) { session in
+                        Button {
+                            openWindow(value: AgentSessionPayload(sourceID: session.id))
+                        } label: {
+                            HStack(spacing: 6) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(session.title.isEmpty ? "Untitled session" : session.title)
+                                        .font(.system(size: 11, weight: .medium))
+                                        .lineLimit(1)
+                                    HStack(spacing: 6) {
+                                        if session.messageCount > 0 {
+                                            Text("\(session.messageCount) msgs")
+                                                .font(.system(size: 9))
+                                                .foregroundStyle(.secondary)
+                                                .monospacedDigit()
+                                        }
+
+                                        Text(session.projectDisplayName)
+                                            .font(.system(size: 9))
+                                            .foregroundStyle(.secondary.opacity(0.7))
+                                            .lineLimit(1)
+                                            .truncationMode(.middle)
+
+                                        Text(session.timeUpdated, style: .relative)
+                                            .font(.system(size: 9))
+                                            .foregroundStyle(.secondary.opacity(0.6))
+                                    }
+                                }
+                            }
+                            .padding(.vertical, 5)
+                            .padding(.horizontal, 6)
+                        }
+                        .buttonStyle(.plain)
+                        .contentShape(Rectangle())
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    private var sessionSearchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.secondary)
+                .font(.system(size: 10))
+            TextField("Search sessions...", text: $sessionSearchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 10))
+            if !sessionSearchText.isEmpty {
+                Button { sessionSearchText = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                        .font(.system(size: 9))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Shared Views
+
     private var headerBar: some View {
-        HStack {
+        HStack(spacing: 6) {
+            Image(systemName: "tray")
+                .font(.system(size: 11))
             Text("Context")
                 .font(.system(size: 13, weight: .semibold))
-
             Spacer()
-
-            Text("\(contextQueue.ready.count)")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(.secondary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(Capsule().fill(Color.secondary.opacity(0.12)))
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 8)
         .frame(height: 44)
         .background(.bar)
+    }
+
+    private func sectionHeader(title: String, systemImage: String, badge: Int, isExpanded: Bool, onTap: (() -> Void)?) -> some View {
+        Button {
+            onTap?()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 12)
+
+                Image(systemName: systemImage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+
+                Spacer()
+
+                Text("\(badge)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(Color.secondary.opacity(0.1)))
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 6)
+    }
+
+    @ViewBuilder
+    private var directoryFilterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4) {
+                Button {
+                    selectedDirectory = nil
+                } label: {
+                    Text("All")
+                        .font(.system(size: 10))
+                        .fontWeight(selectedDirectory == nil ? .semibold : .regular)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule().fill(selectedDirectory == nil ? Color.accentColor.opacity(0.15) : Color.clear)
+                        )
+                }
+                .buttonStyle(.plain)
+
+                ForEach(directories, id: \.directory) { entry in
+                    let lastComponent = (entry.directory as NSString).lastPathComponent
+                    Button {
+                        selectedDirectory = entry.directory
+                    } label: {
+                        HStack(spacing: 2) {
+                            Text(lastComponent)
+                                .font(.system(size: 10))
+                                .fontWeight(selectedDirectory == entry.directory ? .semibold : .regular)
+                            Text("\(entry.sessionCount)")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule().fill(selectedDirectory == entry.directory ? Color.accentColor.opacity(0.15) : Color.clear)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+        }
     }
 
     private var searchBar: some View {
@@ -224,6 +508,26 @@ struct ContextTrayView: View {
         .padding(.vertical, 6)
         .frame(height: 36)
         .background(.bar)
+    }
+
+    // MARK: - Helpers
+
+    private func loadSessionData() {
+        guard !isLoadingSessions else { return }
+        isLoadingSessions = true
+
+        Task.detached { [reader] in
+            let fetchedSessions = reader.fetchSessions(limit: 100)
+            let fetchedDirectories = reader.fetchDirectories()
+            let fetchedTotal = reader.totalSessionCount()
+
+            await MainActor.run {
+                self.sessions = fetchedSessions
+                self.directories = fetchedDirectories
+                self.totalSessionCount = fetchedTotal
+                self.isLoadingSessions = false
+            }
+        }
     }
 
     private func openDetail(item: ContextItem) {

--- a/Vapor/Vapor/Views/ContextTrayView.swift
+++ b/Vapor/Vapor/Views/ContextTrayView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct ContextTrayView: View {
     @Environment(ContextQueueService.self) private var contextQueue
     @Environment(MainWindowFocusStore.self) private var focusStore
+    @Environment(UserPreferences.self) private var preferences
     @Environment(\.openWindow) private var openWindow
 
     @State private var searchText = ""
@@ -19,6 +20,8 @@ struct ContextTrayView: View {
     @State private var totalSessionCount: Int = 0
     @State private var isLoadingSessions = false
     @State private var sessionSearchText = ""
+    @State private var sessionRefreshTask: Task<Void, Never>?
+    @State private var lastSessionSignature: String?
 
     private var reader: OpenCodeReader { .shared }
 
@@ -76,6 +79,14 @@ struct ContextTrayView: View {
         }
         .frame(width: 248)
         .background(Color(nsColor: .windowBackgroundColor))
+        .onDisappear { stopSessionPolling() }
+        .onChange(of: preferences.agentSessionRefreshInterval) { _, _ in
+            restartSessionPollingIfNeeded()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            guard agentSectionExpanded else { return }
+            refreshSessionsIfNeeded()
+        }
     }
 
     // MARK: - Captured Section
@@ -198,8 +209,13 @@ struct ContextTrayView: View {
                 withAnimation(.easeInOut(duration: 0.15)) {
                     agentSectionExpanded.toggle()
                 }
-                if agentSectionExpanded && sessions.isEmpty && !isLoadingSessions {
-                    loadSessionData(directory: selectedDirectory)
+                if agentSectionExpanded {
+                    if sessions.isEmpty && !isLoadingSessions {
+                        loadSessionData(directory: selectedDirectory)
+                    }
+                    startSessionPolling()
+                } else {
+                    stopSessionPolling()
                 }
             } label: {
                 HStack(spacing: 6) {
@@ -216,6 +232,18 @@ struct ContextTrayView: View {
                         .font(.system(size: 12, weight: .semibold))
 
                     Spacer()
+
+                    if agentSectionExpanded {
+                        Button {
+                            loadSessionData(directory: selectedDirectory, force: true)
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Refresh sessions")
+                    }
 
                     if totalSessionCount > 0 {
                         Text("\(totalSessionCount)")
@@ -396,7 +424,7 @@ struct ContextTrayView: View {
             HStack(spacing: 4) {
                 Button {
                     selectedDirectory = nil
-                    loadSessionData(directory: nil)
+                    loadSessionData(directory: nil, force: true)
                 } label: {
                     Text("All")
                         .font(.system(size: 10))
@@ -413,7 +441,7 @@ struct ContextTrayView: View {
                     let lastComponent = (entry.directory as NSString).lastPathComponent
                     Button {
                         selectedDirectory = entry.directory
-                        loadSessionData(directory: entry.directory)
+                        loadSessionData(directory: entry.directory, force: true)
                     } label: {
                         HStack(spacing: 2) {
                             Text(lastComponent)
@@ -517,20 +545,59 @@ struct ContextTrayView: View {
 
     // MARK: - Helpers
 
-    private func loadSessionData(directory: String? = nil) {
+    private func loadSessionData(directory: String? = nil, force: Bool = false) {
         guard !isLoadingSessions else { return }
         isLoadingSessions = true
+        if force { lastSessionSignature = nil }
 
         Task.detached { [reader, directory] in
+            let signature = reader.sessionListSignature(directory: directory)
             let fetchedSessions = reader.fetchSessions(limit: 100, directory: directory)
             let fetchedDirectories = reader.fetchDirectories()
             let fetchedTotal = reader.totalSessionCount()
 
             await MainActor.run {
+                self.lastSessionSignature = signature
                 self.sessions = fetchedSessions
                 self.directories = fetchedDirectories
                 self.totalSessionCount = fetchedTotal
                 self.isLoadingSessions = false
+            }
+        }
+    }
+
+    private func startSessionPolling() {
+        guard sessionRefreshTask == nil,
+              let interval = preferences.agentSessionRefreshInterval.duration else { return }
+
+        sessionRefreshTask = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: interval)
+                guard !Task.isCancelled else { break }
+                refreshSessionsIfNeeded()
+            }
+        }
+    }
+
+    private func stopSessionPolling() {
+        sessionRefreshTask?.cancel()
+        sessionRefreshTask = nil
+    }
+
+    private func restartSessionPollingIfNeeded() {
+        stopSessionPolling()
+        guard agentSectionExpanded else { return }
+        startSessionPolling()
+    }
+
+    private func refreshSessionsIfNeeded() {
+        guard agentSectionExpanded, !isLoadingSessions else { return }
+        let directory = selectedDirectory
+        Task.detached { [reader, directory, lastSessionSignature] in
+            let signature = reader.sessionListSignature(directory: directory)
+            guard signature != lastSessionSignature else { return }
+            await MainActor.run {
+                loadSessionData(directory: directory)
             }
         }
     }

--- a/Vapor/Vapor/Views/ContextTrayView.swift
+++ b/Vapor/Vapor/Views/ContextTrayView.swift
@@ -33,10 +33,6 @@ struct ContextTrayView: View {
     private var filteredSessions: [OpenCodeSession] {
         var result = sessions
 
-        if let directory = selectedDirectory {
-            result = result.filter { $0.directory == directory }
-        }
-
         if !sessionSearchText.isEmpty {
             let query = sessionSearchText.lowercased()
             result = result.filter {
@@ -203,7 +199,7 @@ struct ContextTrayView: View {
                     agentSectionExpanded.toggle()
                 }
                 if agentSectionExpanded && sessions.isEmpty && !isLoadingSessions {
-                    loadSessionData()
+                    loadSessionData(directory: selectedDirectory)
                 }
             } label: {
                 HStack(spacing: 6) {
@@ -255,27 +251,28 @@ struct ContextTrayView: View {
 
     @ViewBuilder
     private var sessionListView: some View {
-        Group {
+        VStack(alignment: .leading, spacing: 0) {
+            sessionSearchField
+
+            if directories.count > 1 {
+                directoryFilterBar
+                Divider()
+            }
+
             if filteredSessions.isEmpty {
                 VStack(spacing: 6) {
                     Spacer()
                     Image(systemName: "terminal")
                         .font(.system(size: 22))
                         .foregroundStyle(.secondary.opacity(0.4))
-                    Text(sessionSearchText.isEmpty ? "No sessions found" : "No matching sessions")
+                    Text(emptySessionsMessage)
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
                     Spacer()
                 }
-                .frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity, minHeight: 120)
             } else {
-                sessionSearchField
-
-                if directories.count > 1 {
-                    directoryFilterBar
-                    Divider()
-                }
-
                 LazyVStack(alignment: .leading, spacing: 2) {
                     ForEach(filteredSessions) { session in
                         Button {
@@ -316,6 +313,12 @@ struct ContextTrayView: View {
                 .padding(.vertical, 4)
             }
         }
+    }
+
+    private var emptySessionsMessage: String {
+        if !sessionSearchText.isEmpty { return "No matching sessions" }
+        if selectedDirectory != nil { return "No sessions loaded for this project" }
+        return "No sessions found"
     }
 
     private var sessionSearchField: some View {
@@ -393,6 +396,7 @@ struct ContextTrayView: View {
             HStack(spacing: 4) {
                 Button {
                     selectedDirectory = nil
+                    loadSessionData(directory: nil)
                 } label: {
                     Text("All")
                         .font(.system(size: 10))
@@ -409,6 +413,7 @@ struct ContextTrayView: View {
                     let lastComponent = (entry.directory as NSString).lastPathComponent
                     Button {
                         selectedDirectory = entry.directory
+                        loadSessionData(directory: entry.directory)
                     } label: {
                         HStack(spacing: 2) {
                             Text(lastComponent)
@@ -512,12 +517,12 @@ struct ContextTrayView: View {
 
     // MARK: - Helpers
 
-    private func loadSessionData() {
+    private func loadSessionData(directory: String? = nil) {
         guard !isLoadingSessions else { return }
         isLoadingSessions = true
 
-        Task.detached { [reader] in
-            let fetchedSessions = reader.fetchSessions(limit: 100)
+        Task.detached { [reader, directory] in
+            let fetchedSessions = reader.fetchSessions(limit: 100, directory: directory)
             let fetchedDirectories = reader.fetchDirectories()
             let fetchedTotal = reader.totalSessionCount()
 

--- a/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
+++ b/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
@@ -22,6 +22,7 @@ struct OpenCodeSessionWindowView: View {
     @State private var searchQuery = ""
     @State private var searchResults: [TurnSearchResult] = []
     @State private var isSearching = false
+    @State private var searchTask: Task<Void, Never>?
     @State private var highlightedTurnID: String?
     @State private var highlightedSearchQuery = ""
     @State private var isHighlightPulsing = false
@@ -1034,12 +1035,12 @@ extension OpenCodeSessionWindowView {
                 .font(.body)
                 .focused($isSearchFieldFocused)
                 .disabled(!canSearchCurrentSession)
-                .onSubmit { performSearch() }
+                .onSubmit {
+                    searchTask?.cancel()
+                    performSearch()
+                }
                 .onChange(of: searchQuery) { _, _ in
-                    Task {
-                        try? await Task.sleep(for: .milliseconds(250))
-                        await MainActor.run { performSearch() }
-                    }
+                    scheduleSearch()
                 }
 
             if !searchQuery.isEmpty {
@@ -1165,8 +1166,8 @@ extension OpenCodeSessionWindowView {
                       let text = row["chunk_text"] as? String,
                       let turnSourceID = row["turn_source_id"] as? String,
                       let sessionID = row["session_id"] as? String,
-                      let chunkIndex = row["chunk_index"] as? Int,
-                      let distance = row["distance"] as? Double else { return nil }
+                      let chunkIndex = intValue(row["chunk_index"]),
+                      let distance = doubleValue(row["distance"]) else { return nil }
                 return TurnSearchResult(
                     id: id,
                     turnSourceID: turnSourceID,
@@ -1177,8 +1178,22 @@ extension OpenCodeSessionWindowView {
                 )
             }
             await MainActor.run {
+                guard query == searchQuery.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
                 searchResults = results
                 isSearching = false
+            }
+        }
+    }
+
+    private func scheduleSearch() {
+        searchTask?.cancel()
+        let scheduledQuery = searchQuery
+        searchTask = Task {
+            try? await Task.sleep(for: .milliseconds(250))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard scheduledQuery == searchQuery else { return }
+                performSearch()
             }
         }
     }
@@ -1235,6 +1250,8 @@ extension OpenCodeSessionWindowView {
             isSearchPresented = false
         }
         isSearchFieldFocused = false
+        searchTask?.cancel()
+        searchTask = nil
         searchQuery = ""
         searchResults = []
         isSearching = false
@@ -1307,6 +1324,28 @@ extension OpenCodeSessionWindowView {
             .map(String.init)
             .filter { $0.count >= 3 }
         return Array(Set(cleaned)).sorted { $0.count > $1.count }
+    }
+
+    private func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int: return int
+        case let int64 as Int64: return Int(int64)
+        case let int32 as Int32: return Int(int32)
+        case let double as Double: return Int(double)
+        case let string as String: return Int(string)
+        default: return nil
+        }
+    }
+
+    private func doubleValue(_ value: Any?) -> Double? {
+        switch value {
+        case let double as Double: return double
+        case let int as Int: return Double(int)
+        case let int64 as Int64: return Double(int64)
+        case let int32 as Int32: return Double(int32)
+        case let string as String: return Double(string)
+        default: return nil
+        }
     }
 
     private var canSearchCurrentSession: Bool {

--- a/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
+++ b/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
@@ -525,6 +525,7 @@ struct OpenCodeSessionWindowView: View {
     private func turnCard(_ message: OpenCodeMessage) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             turnHeader(message)
+            actionSummaryView(for: message)
             turnContent(message)
         }
         .padding(12)
@@ -605,11 +606,51 @@ struct OpenCodeSessionWindowView: View {
 
     private func roleBadgeInfo(_ role: String) -> (String, Color) {
         switch role {
-        case "user": return ("You", .blue)
+        case "user": return ("User", .blue)
         case "assistant": return ("AI", .green)
         case "system": return ("System", .orange)
         default: return (role.capitalized, .secondary)
         }
+    }
+
+    @ViewBuilder
+    private func actionSummaryView(for message: OpenCodeMessage) -> some View {
+        let summary = actionSummary(for: message)
+        if let summary {
+            HStack(spacing: 6) {
+                Image(systemName: summary.failed > 0 ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(summary.failed > 0 ? .orange : .green)
+                Text(summary.label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color(nsColor: .textBackgroundColor).opacity(0.7))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+    }
+
+    private func actionSummary(for message: OpenCodeMessage) -> (label: String, failed: Int)? {
+        guard message.role == "assistant" else { return nil }
+        let parts = partsCache[message.id] ?? []
+        let tools = parts.compactMap { part -> String? in
+            if case .tool(_, _, let status, _, _, _) = part.kind { return status }
+            return nil
+        }
+        guard !tools.isEmpty else { return nil }
+
+        let failed = tools.filter { $0 == "error" || $0 == "failed" }.count
+        let running = tools.filter { $0 == "running" }.count
+        let completed = tools.filter { $0 == "completed" }.count
+
+        var segments = ["Actions: \(tools.count) tool\(tools.count == 1 ? "" : "s")"]
+        if completed > 0 { segments.append("\(completed) succeeded") }
+        if failed > 0 { segments.append("\(failed) failed") }
+        if running > 0 { segments.append("\(running) running") }
+        return (segments.joined(separator: " · "), failed)
     }
 
     // MARK: - Turn Content
@@ -656,7 +697,7 @@ struct OpenCodeSessionWindowView: View {
                         Image(systemName: "ellipsis")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
-                        Text("show tools & details")
+                        Text("show actions & details")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -716,7 +757,8 @@ struct OpenCodeSessionWindowView: View {
     @ViewBuilder
     private func toolCallView(name: String, status: String, input: String?, output: String?, title: String?, partID: String) -> some View {
         let isExpanded = expandedToolCalls.contains(partID)
-        let displayTitle = title ?? name
+        let displayTitle = toolSummary(name: name, status: status, input: input, output: output, title: title)
+        let isFailure = status == "error" || status == "failed"
 
         VStack(alignment: .leading, spacing: 0) {
             Button {
@@ -729,14 +771,14 @@ struct OpenCodeSessionWindowView: View {
                 }
             } label: {
                 HStack(spacing: 6) {
-                    Image(systemName: "wrench.fill")
+                    Image(systemName: toolIcon(name: name, status: status))
                         .font(.caption)
-                        .foregroundStyle(.purple)
+                        .foregroundStyle(isFailure ? .red : .purple)
 
                     Text(displayTitle)
                         .font(.caption)
                         .fontWeight(.medium)
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(isFailure ? .red : .primary)
                         .lineLimit(1)
 
                     statusIndicator(status)
@@ -764,8 +806,66 @@ struct OpenCodeSessionWindowView: View {
             }
         }
         .padding(8)
-        .background(Color.purple.opacity(0.05))
+        .background((isFailure ? Color.red : Color.purple).opacity(0.05))
         .clipShape(RoundedRectangle(cornerRadius: 4))
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(isFailure ? Color.red.opacity(0.22) : Color.clear, lineWidth: 1)
+        )
+    }
+
+    private func toolIcon(name: String, status: String) -> String {
+        if status == "error" || status == "failed" { return "exclamationmark.triangle.fill" }
+        switch name.lowercased() {
+        case "bash": return "terminal"
+        case "read", "glob", "grep": return "doc.text.magnifyingglass"
+        case "edit", "write", "apply_patch": return "pencil.and.outline"
+        default: return "wrench.fill"
+        }
+    }
+
+    private func toolSummary(name: String, status: String, input: String?, output: String?, title: String?) -> String {
+        if let title, !title.isEmpty { return title }
+        let lowerName = name.lowercased()
+        let inputText = input ?? ""
+        let prefix = status == "error" || status == "failed" ? "Failed" : toolVerb(for: lowerName)
+
+        if lowerName == "bash", let command = toolJSONValue(inputText, key: "command") {
+            return "\(prefix) `\(shorten(command))`"
+        }
+        if ["read", "edit", "write"].contains(lowerName), let filePath = toolJSONValue(inputText, key: "filePath") {
+            return "\(prefix) \((filePath as NSString).lastPathComponent)"
+        }
+        if ["grep", "glob"].contains(lowerName), let pattern = toolJSONValue(inputText, key: "pattern") {
+            return "\(prefix) \(name) `\(shorten(pattern))`"
+        }
+        if status == "error" || status == "failed", let output, !output.isEmpty {
+            return "Failed \(name): \(shorten(output))"
+        }
+        return "\(prefix) \(name)"
+    }
+
+    private func toolVerb(for toolName: String) -> String {
+        switch toolName {
+        case "bash": return "Ran"
+        case "read": return "Read"
+        case "edit", "write", "apply_patch": return "Edited"
+        case "grep", "glob": return "Searched"
+        default: return "Used"
+        }
+    }
+
+    private func toolJSONValue(_ input: String, key: String) -> String? {
+        guard let data = input.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let value = json[key] as? String,
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    private func shorten(_ text: String, limit: Int = 80) -> String {
+        if text.count <= limit { return text }
+        return String(text.prefix(limit - 1)) + "…"
     }
 
     @ViewBuilder
@@ -832,6 +932,10 @@ struct OpenCodeSessionWindowView: View {
                     .font(.caption2)
                     .foregroundStyle(.quaternary)
                 if isExpanded {
+                    Text("AI reasoning")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.tertiary)
                     Text(text)
                         .font(.caption)
                         .foregroundStyle(.tertiary)
@@ -839,7 +943,7 @@ struct OpenCodeSessionWindowView: View {
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else {
-                    Text("reasoning")
+                    Text("AI reasoning")
                         .font(.caption)
                         .foregroundStyle(.quaternary)
                         .italic()

--- a/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
+++ b/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
@@ -1,0 +1,1295 @@
+import SwiftUI
+
+struct OpenCodeSessionWindowView: View {
+    let sourceID: String
+
+    @Environment(VectorizationService.self) private var vectorizationService
+
+    @State private var session: OpenCodeSession?
+    @State private var messages: [OpenCodeMessage] = []
+    @State private var partsCache: [String: [OpenCodePart]] = [:]
+    @State private var loadingParts: Set<String> = []
+    @State private var expandedToolCalls: Set<String> = []
+    @State private var expandedReasoning: Set<String> = []
+    @State private var copiedMessageID: String?
+    @State private var displayedTurnCount: Int = 30
+    @State private var isLoadingMore: Bool = false
+    @State private var totalCost: Double?
+    @State private var isLoadingSession: Bool = true
+    @State private var indexerState: OpenCodeSessionIndexer.IndexState = .idle
+    @State private var importStatus: OpenCodeSessionIndexer.ImportStatus = .notImported
+    @State private var isSearchPresented = false
+    @State private var searchQuery = ""
+    @State private var searchResults: [TurnSearchResult] = []
+    @State private var isSearching = false
+    @State private var highlightedTurnID: String?
+    @State private var highlightedSearchQuery = ""
+    @State private var isHighlightPulsing = false
+    @State private var isIndexDetailsPresented = false
+    @FocusState private var isSearchFieldFocused: Bool
+
+    private struct ToolCallInfo {
+        let name: String
+        let status: String
+        let input: String?
+        let output: String?
+        let title: String?
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(16)
+                .background(Color(nsColor: .windowBackgroundColor))
+
+            Divider()
+
+            ZStack(alignment: .top) {
+                ScrollViewReader { proxy in
+                    ZStack(alignment: .top) {
+                        ScrollView {
+                            LazyVStack(spacing: 8) {
+                                ForEach(displayedTurns) { message in
+                                    turnCard(message)
+                                        .id(message.id)
+                                }
+
+                                if hasMoreTurns {
+                                    loadMoreSentinel
+                                }
+                            }
+                            .padding(16)
+                        }
+
+                        if isSearchPresented {
+                            searchOverlay(proxy: proxy)
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            let indexer = OpenCodeSessionIndexer.shared
+            indexerState = indexer.state
+            importStatus = indexer.status(for: sourceID)
+            loadSession()
+            observeIndexerState()
+        }
+    }
+
+    private var displayedTurns: [OpenCodeMessage] {
+        Array(messages.prefix(displayedTurnCount))
+    }
+
+    private var hasMoreTurns: Bool {
+        displayedTurnCount < messages.count
+    }
+
+    // MARK: - Load Data
+
+    private func loadSession() {
+        isLoadingSession = true
+        Task.detached { [sourceID] in
+            let reader = OpenCodeReader.shared
+            let fetchedSessions = reader.fetchSessions(limit: 1)
+            let session = fetchedSessions.first { $0.id == sourceID }
+            let fetchedMessages = reader.fetchAllMessages(sessionID: sourceID)
+            let cost = fetchedMessages.compactMap(\.cost).reduce(0, +)
+
+            await MainActor.run {
+                self.session = session
+                self.messages = fetchedMessages
+                self.totalCost = cost > 0 ? cost : nil
+                self.isLoadingSession = false
+                self.preloadTextParts()
+                self.checkImportStatus()
+            }
+        }
+    }
+
+    private func checkImportStatus() {
+        guard let session else { return }
+        let sessionTimeUpdated = session.timeUpdated
+        Task { [sourceID] in
+            let indexer = OpenCodeSessionIndexer.shared
+            let status = await indexer.checkImportState(
+                sourceID: sourceID,
+                sessionTimeUpdated: sessionTimeUpdated,
+                vectorizationService: vectorizationService
+            )
+            await MainActor.run {
+                importStatus = status
+            }
+        }
+    }
+
+    private func observeIndexerState() {
+        let indexer = OpenCodeSessionIndexer.shared
+        withObservationTracking {
+            _ = indexer.state
+            _ = indexer.status(for: sourceID)
+        } onChange: {
+            Task { @MainActor in
+                indexerState = indexer.state
+                importStatus = indexer.status(for: sourceID)
+                observeIndexerState()
+            }
+        }
+    }
+
+    private func preloadTextParts() {
+        for message in messages {
+            let messageID = message.id
+            guard partsCache[messageID] == nil, !loadingParts.contains(messageID) else { continue }
+            loadingParts.insert(messageID)
+            Task.detached { [sourceID] in
+                let reader = OpenCodeReader.shared
+                let parts = reader.fetchParts(messageID: messageID)
+                let textParts = parts.filter { if case .text = $0.kind { true } else { false } }
+                await MainActor.run {
+                    partsCache[messageID] = textParts
+                    loadingParts.remove(messageID)
+                }
+            }
+        }
+    }
+
+    private func loadFullParts(for messageID: String) {
+        guard !loadingParts.contains(messageID) else { return }
+        loadingParts.insert(messageID)
+        Task.detached { [sourceID] in
+            let reader = OpenCodeReader.shared
+            let parts = reader.fetchAllParts(sessionID: sourceID).filter { $0.messageID == messageID }
+            await MainActor.run {
+                partsCache[messageID] = parts
+                loadingParts.remove(messageID)
+            }
+        }
+    }
+
+    // MARK: - Load More
+
+    private var loadMoreSentinel: some View {
+        Group {
+            if isLoadingMore {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .scaleEffect(0.5)
+                    Text("Loading more...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+            } else {
+                Color.clear
+                    .frame(height: 1)
+                    .onAppear {
+                        loadMore()
+                    }
+            }
+        }
+    }
+
+    private func loadMore() {
+        guard hasMoreTurns, !isLoadingMore else { return }
+        isLoadingMore = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            displayedTurnCount += 30
+            isLoadingMore = false
+        }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var header: some View {
+        if let session {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(session.title.isEmpty ? "Untitled session" : session.title)
+                            .font(.title3)
+                            .fontWeight(.bold)
+                            .lineLimit(2)
+
+                        HStack(spacing: 12) {
+                            Label {
+                                Text(session.projectDisplayName)
+                            } icon: {
+                                Image(systemName: "folder")
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                            Label {
+                                Text("\(messages.count) turns")
+                            } icon: {
+                                Image(systemName: "text.bubble")
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                            if let version = session.version {
+                                Text("v\(version)")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                                    .monospacedDigit()
+                            }
+
+                            Text(session.timeUpdated, format: .dateTime.month().day().hour().minute())
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            if let cost = totalCost {
+                                Text("$\(String(format: "%.2f", cost))")
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(.orange)
+                                    .monospacedDigit()
+                            }
+                        }
+                    }
+
+                    Spacer()
+
+                    HStack(spacing: 6) {
+                        searchToggleButton
+                        importAndIndexButton
+                        indexDetailsButton
+                    }
+                }
+            }
+        } else {
+            HStack {
+                ProgressView()
+                    .scaleEffect(0.6)
+                Text("Loading session...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var searchToggleButton: some View {
+        Button {
+            presentSearchOverlay()
+        } label: {
+            Image(systemName: "magnifyingglass")
+                .font(.caption)
+                .foregroundStyle(isSearchPresented ? Color.accentColor : .secondary)
+                .frame(width: 24, height: 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isSearchPresented ? Color.accentColor.opacity(0.12) : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut("f", modifiers: .command)
+        .help("Search turns")
+    }
+
+    @ViewBuilder
+    private var importAndIndexButton: some View {
+        let isIndexerActive: Bool = {
+            switch indexerState {
+            case .importing, .indexing:
+                true
+            case .idle, .done, .error:
+                false
+            }
+        }()
+        let isIndexerForThisSession: Bool = {
+            switch indexerState {
+            case .importing(let sid, _, _), .indexing(let sid, _, _):
+                return sid == sourceID
+            default:
+                return false
+            }
+        }()
+
+        if isIndexerActive && isIndexerForThisSession {
+            switch indexerState {
+            case .idle:
+                EmptyView()
+            case .importing(_, let current, let total):
+                HStack(spacing: 4) {
+                    ProgressView()
+                        .scaleEffect(0.4)
+                        .controlSize(.mini)
+                    Text("Importing \(current)/\(total)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.accentColor.opacity(0.06))
+                .clipShape(Capsule())
+            case .indexing(_, let current, let total):
+                HStack(spacing: 4) {
+                    ProgressView()
+                        .scaleEffect(0.4)
+                        .controlSize(.mini)
+                    Text(total > 0 ? "Updating search \(current)/\(total)" : "Updating search...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.accentColor.opacity(0.06))
+                .clipShape(Capsule())
+            case .done(_, let turnCount, let chunkCount):
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                    Text("Search ready")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .help("\(turnCount) turns, \(chunkCount) chunks indexed")
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.green.opacity(0.06))
+                .clipShape(Capsule())
+            case .error(let message):
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(1)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.red.opacity(0.06))
+                .clipShape(Capsule())
+            }
+        } else {
+            switch importStatus {
+            case .notImported:
+                Button {
+                    let indexer = OpenCodeSessionIndexer.shared
+                    indexer.importAndIndex(sourceID: sourceID, vectorizationService: vectorizationService)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "square.and.arrow.down")
+                            .font(.caption)
+                        Text("Import & Index")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.accentColor.opacity(0.12))
+                    .foregroundStyle(Color.accentColor)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            case .ready(let turnCount, let chunkCount, let vectorCount):
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                    Text("Search ready")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .help("\(turnCount) turns, \(chunkCount) chunks, \(vectorCount) vectors")
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.green.opacity(0.06))
+                .clipShape(Capsule())
+            case .dirty(let turnCount, let chunkCount, let vectorCount):
+                Button {
+                    let indexer = OpenCodeSessionIndexer.shared
+                    indexer.importAndIndex(sourceID: sourceID, vectorizationService: vectorizationService)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                            .font(.caption)
+                        Text("Update Search")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.orange.opacity(0.12))
+                    .foregroundStyle(.orange)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .help("\(turnCount) turns, \(chunkCount) chunks, \(vectorCount) vectors — session changed")
+            case .needsRepair(let turnCount, let chunkCount, let vectorCount):
+                Button {
+                    let indexer = OpenCodeSessionIndexer.shared
+                    indexer.repairSearchIndex(sourceID: sourceID, vectorizationService: vectorizationService)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "wrench.and.screwdriver")
+                            .font(.caption)
+                        Text("Repair Search")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.orange.opacity(0.12))
+                    .foregroundStyle(.orange)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .help("Search index incomplete: \(turnCount) turns, \(chunkCount) chunks, \(vectorCount) vectors")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var indexDetailsButton: some View {
+        Button {
+            isIndexDetailsPresented.toggle()
+        } label: {
+            Image(systemName: "info.circle")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 24, height: 24)
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $isIndexDetailsPresented, arrowEdge: .bottom) {
+            searchIndexDetailsPopover
+        }
+        .help("Search index details")
+    }
+
+    private var searchIndexDetailsPopover: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Search Index")
+                .font(.headline)
+
+            Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 6) {
+                GridRow {
+                    Text("Status").foregroundStyle(.secondary)
+                    Text(searchIndexStatusLabel)
+                }
+                if let counts = searchIndexCounts {
+                    GridRow {
+                        Text("Turns").foregroundStyle(.secondary)
+                        Text("\(counts.turns)")
+                    }
+                    GridRow {
+                        Text("Chunks").foregroundStyle(.secondary)
+                        Text("\(counts.chunks)")
+                    }
+                    GridRow {
+                        Text("Vectors").foregroundStyle(.secondary)
+                        Text("\(counts.vectors)")
+                    }
+                }
+                GridRow {
+                    Text("Model").foregroundStyle(.secondary)
+                    Text(vectorizationService.providerDisplayName)
+                }
+            }
+            .font(.caption)
+
+        }
+        .padding(14)
+        .frame(width: 260)
+    }
+
+    private var searchIndexStatusLabel: String {
+        switch importStatus {
+        case .notImported: "Not imported"
+        case .ready: "Search ready"
+        case .dirty: "Needs update"
+        case .needsRepair: "Needs repair"
+        }
+    }
+
+    private var searchIndexCounts: (turns: Int, chunks: Int, vectors: Int)? {
+        switch importStatus {
+        case .notImported:
+            nil
+        case .ready(let turnCount, let chunkCount, let vectorCount),
+             .dirty(let turnCount, let chunkCount, let vectorCount),
+             .needsRepair(let turnCount, let chunkCount, let vectorCount):
+            (turnCount, chunkCount, vectorCount)
+        }
+    }
+
+    // MARK: - Turn Card
+
+    @ViewBuilder
+    private func turnCard(_ message: OpenCodeMessage) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            turnHeader(message)
+            turnContent(message)
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(highlightedTurnID == message.id ? Color.accentColor.opacity(isHighlightPulsing ? 0.95 : 0.25) : Color.clear, lineWidth: 2.5)
+                .scaleEffect(highlightedTurnID == message.id && isHighlightPulsing ? 1.012 : 1.0)
+                .shadow(color: highlightedTurnID == message.id ? Color.accentColor.opacity(isHighlightPulsing ? 0.42 : 0.08) : Color.clear, radius: 8)
+                .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: isHighlightPulsing)
+        )
+    }
+
+    @ViewBuilder
+    private func turnHeader(_ message: OpenCodeMessage) -> some View {
+        HStack(spacing: 8) {
+            roleBadge(message.role)
+
+            Text(message.timeCreated, format: .dateTime.hour().minute().second())
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .monospacedDigit()
+
+            if let agent = message.agent, message.role == "assistant" {
+                Text(agent)
+                    .font(.caption2)
+                    .foregroundStyle(.quaternary)
+            }
+
+            if message.role == "assistant" {
+                if let modelID = message.modelID {
+                    Text(modelID)
+                        .font(.caption2)
+                        .foregroundStyle(.quaternary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            if let cost = message.cost, cost > 0 {
+                Text("$\(String(format: "%.4f", cost))")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .monospacedDigit()
+            }
+
+            if let tokens = message.tokens, tokens.total > 0 {
+                Text("\(tokens.total) tok")
+                    .font(.caption2)
+                    .foregroundStyle(.quaternary)
+                    .monospacedDigit()
+            }
+
+            Button {
+                copyTurnText(message)
+            } label: {
+                Image(systemName: copiedMessageID == message.id ? "checkmark" : "doc.on.doc")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+        }
+    }
+
+    @ViewBuilder
+    private func roleBadge(_ role: String) -> some View {
+        let (text, color) = roleBadgeInfo(role)
+        Text(text)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(Capsule())
+    }
+
+    private func roleBadgeInfo(_ role: String) -> (String, Color) {
+        switch role {
+        case "user": return ("You", .blue)
+        case "assistant": return ("AI", .green)
+        case "system": return ("System", .orange)
+        default: return (role.capitalized, .secondary)
+        }
+    }
+
+    // MARK: - Turn Content
+
+    @ViewBuilder
+    private func turnContent(_ message: OpenCodeMessage) -> some View {
+        let parts = partsCache[message.id] ?? []
+        let isLoading = loadingParts.contains(message.id)
+
+        if isLoading && parts.isEmpty {
+            HStack(spacing: 4) {
+                ProgressView()
+                    .scaleEffect(0.4)
+                    .frame(width: 10, height: 10)
+                Text("loading...")
+                    .font(.caption)
+                    .foregroundStyle(.quaternary)
+                    .italic()
+            }
+        } else if parts.isEmpty {
+            Button {
+                loadFullParts(for: message.id)
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "eye")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text("show content")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+        } else {
+            ForEach(parts) { part in
+                contentPartView(part)
+            }
+            let textOnly = parts.allSatisfy { if case .text = $0.kind { true } else { false } }
+            if textOnly {
+                Button {
+                    loadFullParts(for: message.id)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "ellipsis")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text("show tools & details")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Part Views
+
+    @ViewBuilder
+    private func contentPartView(_ part: OpenCodePart) -> some View {
+        switch part.kind {
+        case .text(let text):
+            if !text.isEmpty {
+                Text(part.messageID == highlightedTurnID ? highlightedText(text, query: highlightedSearchQuery) : AttributedString(text))
+                    .font(.body)
+                    .textSelection(.enabled)
+            }
+        case .tool(let name, let callID, let status, let input, let output, let title):
+            toolCallView(name: name, status: status, input: input, output: output, title: title, partID: part.id)
+        case .reasoning(let text):
+            reasoningView(text: text, partID: part.id)
+        case .stepStart, .stepFinish, .compaction, .unknown:
+            EmptyView()
+        case .patch(_, let files):
+            if !files.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    Image(systemName: "doc.fill")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    ForEach(files, id: \.self) { file in
+                        Text((file as NSString).lastPathComponent)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                .padding(8)
+                .background(Color(nsColor: .textBackgroundColor))
+            }
+        case .file(_, let filename, _):
+            HStack(spacing: 4) {
+                Image(systemName: "doc")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(filename ?? "attachment")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Tool Call
+
+    @ViewBuilder
+    private func toolCallView(name: String, status: String, input: String?, output: String?, title: String?, partID: String) -> some View {
+        let isExpanded = expandedToolCalls.contains(partID)
+        let displayTitle = title ?? name
+
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    if isExpanded {
+                        expandedToolCalls.remove(partID)
+                    } else {
+                        expandedToolCalls.insert(partID)
+                    }
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "wrench.fill")
+                        .font(.caption)
+                        .foregroundStyle(.purple)
+
+                    Text(displayTitle)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    statusIndicator(status)
+
+                    Spacer()
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.caption2)
+                        .foregroundStyle(.quaternary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 4) {
+                    if let input {
+                        toolOutputSection(label: "Input", content: input)
+                    }
+                    if let output, !output.isEmpty {
+                        toolOutputSection(label: "Output", content: output)
+                    }
+                }
+                .padding(.top, 6)
+            }
+        }
+        .padding(8)
+        .background(Color.purple.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+
+    @ViewBuilder
+    private func statusIndicator(_ status: String) -> some View {
+        let color: Color = switch status {
+        case "completed": .green
+        case "running": .blue
+        case "error": .red
+        default: Color.secondary.opacity(0.5)
+        }
+        let label: String = switch status {
+        case "completed": "done"
+        case "running": "running"
+        case "error": "error"
+        default: status
+        }
+        Circle()
+            .fill(color)
+            .frame(width: 6, height: 6)
+        Text(label)
+            .font(.caption2)
+            .foregroundStyle(.quaternary)
+    }
+
+    @ViewBuilder
+    private func toolOutputSection(label: String, content: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .fontWeight(.medium)
+                .foregroundStyle(.secondary)
+
+            ScrollView {
+                Text(content)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 200)
+        }
+        .padding(6)
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+
+    // MARK: - Reasoning
+
+    @ViewBuilder
+    private func reasoningView(text: String, partID: String) -> some View {
+        let isExpanded = expandedReasoning.contains(partID)
+
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                if isExpanded {
+                    expandedReasoning.remove(partID)
+                } else {
+                    expandedReasoning.insert(partID)
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: isExpanded ? "eye.fill" : "eye.slash")
+                    .font(.caption2)
+                    .foregroundStyle(.quaternary)
+                if isExpanded {
+                    Text(text)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .italic()
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    Text("reasoning")
+                        .font(.caption)
+                        .foregroundStyle(.quaternary)
+                        .italic()
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Helpers
+
+    private func copyTurnText(_ message: OpenCodeMessage) {
+        let parts = partsCache[message.id] ?? []
+        let textParts: [String] = parts.compactMap {
+            if case .text(let text) = $0.kind { return text }
+            return nil
+        }
+        let combined = textParts.joined(separator: "\n")
+        if !combined.isEmpty {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(combined, forType: .string)
+        }
+        copiedMessageID = message.id
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            if copiedMessageID == message.id {
+                copiedMessageID = nil
+            }
+        }
+    }
+}
+
+// MARK: - Search Types
+
+struct TurnSearchResult: Identifiable, Sendable {
+    let id: String
+    let turnSourceID: String
+    let sessionID: String
+    let chunkIndex: Int
+    let chunkText: String
+    let distance: Double
+}
+
+// MARK: - Search Views
+
+extension OpenCodeSessionWindowView {
+
+    @ViewBuilder
+    private func searchOverlay(proxy: ScrollViewProxy) -> some View {
+        ZStack(alignment: .top) {
+            Color.black.opacity(0.18)
+                .ignoresSafeArea()
+                .onTapGesture { dismissSearchOverlay() }
+
+            VStack(spacing: 0) {
+                searchOverlayHeader
+                Divider()
+                searchOverlayContent(proxy: proxy)
+            }
+            .frame(maxWidth: 560, maxHeight: 520)
+            .background(Color(nsColor: .windowBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.7), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.22), radius: 24, y: 10)
+            .padding(.top, 18)
+            .padding(.horizontal, 24)
+            .onAppear {
+                searchQuery = ""
+                searchResults = []
+                DispatchQueue.main.async { isSearchFieldFocused = true }
+            }
+        }
+        .transition(.opacity.combined(with: .move(edge: .top)))
+    }
+
+    private var searchOverlayHeader: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 14))
+                .foregroundStyle(.secondary)
+
+            TextField("Search this session...", text: $searchQuery)
+                .textFieldStyle(.plain)
+                .font(.body)
+                .focused($isSearchFieldFocused)
+                .disabled(!canSearchCurrentSession)
+                .onSubmit { performSearch() }
+                .onChange(of: searchQuery) { _, _ in
+                    Task {
+                        try? await Task.sleep(for: .milliseconds(250))
+                        await MainActor.run { performSearch() }
+                    }
+                }
+
+            if !searchQuery.isEmpty {
+                Button {
+                    searchQuery = ""
+                    searchResults = []
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Button { dismissSearchOverlay() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.escape, modifiers: [])
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private func searchOverlayContent(proxy: ScrollViewProxy) -> some View {
+        if let activeState = activeIndexStateForCurrentSession, !hasUsableSearchIndex {
+            VStack(spacing: 10) {
+                ProgressView()
+                    .scaleEffect(0.75)
+                Text(activeIndexTitle(for: activeState))
+                    .font(.headline)
+                Text(activeIndexMessage(for: activeState))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(32)
+        } else if !canSearchCurrentSession {
+            VStack(spacing: 10) {
+                Image(systemName: searchUnavailableIcon)
+                    .font(.title2)
+                    .foregroundStyle(.orange)
+                Text(searchUnavailableTitle)
+                    .font(.headline)
+                Text(searchUnavailableMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Text(searchUnavailableActionHint)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(32)
+        } else if isSearching {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .scaleEffect(0.65)
+                Text("Searching indexed turns...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(28)
+        } else if searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            VStack(spacing: 8) {
+                Text("Search this session")
+                    .font(.headline)
+                Text("Type a phrase, topic, or implementation detail. Results come from indexed turns only.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(32)
+        } else if searchResults.isEmpty {
+            VStack(spacing: 8) {
+                Text("No results")
+                    .font(.headline)
+                Text("This session may not be indexed yet, or no indexed turn matched that query.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(32)
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("\(searchResults.count) result\(searchResults.count == 1 ? "" : "s")")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                    }
+
+                    ForEach(searchResults) { result in
+                        searchResultButton(result, proxy: proxy)
+                    }
+                }
+                .padding(12)
+            }
+        }
+    }
+
+    private func performSearch() {
+        guard canSearchCurrentSession else { return }
+        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { searchResults = []; return }
+        isSearching = true
+
+        Task { [query, sourceID] in
+            let rows = await vectorizationService.searchTurnChunks(matching: query, sessionID: sourceID, limit: 20)
+            let results: [TurnSearchResult] = rows.compactMap { row in
+                guard let id = row["embedding_id"] as? String,
+                      let text = row["chunk_text"] as? String,
+                      let turnSourceID = row["turn_source_id"] as? String,
+                      let sessionID = row["session_id"] as? String,
+                      let chunkIndex = row["chunk_index"] as? Int,
+                      let distance = row["distance"] as? Double else { return nil }
+                return TurnSearchResult(
+                    id: id,
+                    turnSourceID: turnSourceID,
+                    sessionID: sessionID,
+                    chunkIndex: chunkIndex,
+                    chunkText: text,
+                    distance: distance
+                )
+            }
+            await MainActor.run {
+                searchResults = results
+                isSearching = false
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func searchResultButton(_ result: TurnSearchResult, proxy: ScrollViewProxy) -> some View {
+        Button {
+            selectSearchResult(result, proxy: proxy)
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(Color.accentColor.opacity(0.65))
+                        .frame(width: 6, height: 6)
+                    Text(result.turnSourceID.suffix(8))
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(matchStrengthLabel(for: result.distance))
+                        .font(.caption2)
+                        .foregroundStyle(matchStrengthColor(for: result.distance))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(matchStrengthColor(for: result.distance).opacity(0.12)))
+                    Text("Distance \(String(format: "%.3f", result.distance))")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .monospacedDigit()
+                        .help("Cosine distance. Lower is better.")
+                }
+
+                Text(highlightedText(String(result.chunkText.prefix(1_200)), query: searchQuery))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.primary)
+                    .lineLimit(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(12)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.88))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func presentSearchOverlay() {
+        withAnimation(.easeInOut(duration: 0.16)) {
+            isSearchPresented = true
+        }
+        DispatchQueue.main.async { isSearchFieldFocused = true }
+    }
+
+    private func dismissSearchOverlay() {
+        withAnimation(.easeInOut(duration: 0.16)) {
+            isSearchPresented = false
+        }
+        isSearchFieldFocused = false
+        searchQuery = ""
+        searchResults = []
+        isSearching = false
+    }
+
+    private func selectSearchResult(_ result: TurnSearchResult, proxy: ScrollViewProxy) {
+        if let index = messages.firstIndex(where: { $0.id == result.turnSourceID }) {
+            displayedTurnCount = max(displayedTurnCount, index + 1)
+        }
+
+        highlightedTurnID = result.turnSourceID
+        highlightedSearchQuery = searchQuery
+        isHighlightPulsing = false
+        dismissSearchOverlay()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                proxy.scrollTo(result.turnSourceID, anchor: .center)
+            }
+            isHighlightPulsing = true
+        }
+
+        Task {
+            try? await Task.sleep(for: .seconds(3.5))
+            if highlightedTurnID == result.turnSourceID {
+                highlightedTurnID = nil
+                highlightedSearchQuery = ""
+                isHighlightPulsing = false
+            }
+        }
+    }
+
+    private func matchStrengthLabel(for distance: Double) -> String {
+        if distance < 0.30 { return "Strong" }
+        if distance < 0.60 { return "Related" }
+        return "Weak"
+    }
+
+    private func matchStrengthColor(for distance: Double) -> Color {
+        if distance < 0.30 { return .green }
+        if distance < 0.60 { return .orange }
+        return .secondary
+    }
+
+    private func highlightedText(_ text: String, query: String) -> AttributedString {
+        var attributed = AttributedString(text)
+        let terms = highlightTerms(from: query)
+        guard !terms.isEmpty else { return attributed }
+
+        let lowercasedText = text.lowercased()
+        for term in terms {
+            var searchStart = lowercasedText.startIndex
+            while searchStart < lowercasedText.endIndex,
+                  let range = lowercasedText.range(of: term, range: searchStart..<lowercasedText.endIndex) {
+                let startOffset = lowercasedText.distance(from: lowercasedText.startIndex, to: range.lowerBound)
+                let endOffset = lowercasedText.distance(from: lowercasedText.startIndex, to: range.upperBound)
+                let start = attributed.index(attributed.startIndex, offsetByCharacters: startOffset)
+                let end = attributed.index(attributed.startIndex, offsetByCharacters: endOffset)
+                attributed[start..<end].backgroundColor = Color.accentColor.opacity(0.22)
+                attributed[start..<end].foregroundColor = .primary
+                searchStart = range.upperBound
+            }
+        }
+        return attributed
+    }
+
+    private func highlightTerms(from query: String) -> [String] {
+        let cleaned = query
+            .lowercased()
+            .replacingOccurrences(of: "[^a-z0-9]+", with: " ", options: .regularExpression)
+            .split(separator: " ")
+            .map(String.init)
+            .filter { $0.count >= 3 }
+        return Array(Set(cleaned)).sorted { $0.count > $1.count }
+    }
+
+    private var canSearchCurrentSession: Bool {
+        hasUsableSearchIndex
+    }
+
+    private var hasUsableSearchIndex: Bool {
+        switch importStatus {
+        case .ready, .dirty:
+            return true
+        case .notImported, .needsRepair:
+            return false
+        }
+    }
+
+    private var activeIndexStateForCurrentSession: OpenCodeSessionIndexer.IndexState? {
+        switch indexerState {
+        case .importing(let sid, _, _) where sid == sourceID:
+            return indexerState
+        case .indexing(let sid, _, _) where sid == sourceID:
+            return indexerState
+        default:
+            return nil
+        }
+    }
+
+    private func activeIndexTitle(for state: OpenCodeSessionIndexer.IndexState) -> String {
+        switch state {
+        case .importing:
+            "Importing session"
+        case .indexing:
+            "Updating search index"
+        case .idle, .done, .error:
+            "Updating"
+        }
+    }
+
+    private func activeIndexMessage(for state: OpenCodeSessionIndexer.IndexState) -> String {
+        switch state {
+        case .importing(_, let current, let total):
+            total > 0 ? "Imported \(current) of \(total) turns." : "Preparing imported content."
+        case .indexing(_, let current, let total):
+            total > 0 ? "Indexed \(current) of \(total) turns." : "Preparing searchable vectors."
+        case .idle, .done, .error:
+            ""
+        }
+    }
+
+    private var searchUnavailableIcon: String {
+        switch importStatus {
+        case .notImported: "square.and.arrow.down"
+        case .needsRepair: "wrench.and.screwdriver"
+        case .ready, .dirty: "magnifyingglass"
+        }
+    }
+
+    private var searchUnavailableTitle: String {
+        switch importStatus {
+        case .notImported: "Import this session to search"
+        case .needsRepair: "Search index needs repair"
+        case .ready, .dirty: "Search this session"
+        }
+    }
+
+    private var searchUnavailableMessage: String {
+        switch importStatus {
+        case .notImported:
+            "This session has not been added to local search yet."
+        case .needsRepair(let turnCount, let chunkCount, let vectorCount):
+            "Imported content exists, but searchable vectors are missing or incomplete. Turns: \(turnCount), chunks: \(chunkCount), vectors: \(vectorCount)."
+        case .ready, .dirty:
+            ""
+        }
+    }
+
+    private var searchUnavailableActionHint: String {
+        switch importStatus {
+        case .notImported:
+            "Use Import & Index in the window header."
+        case .needsRepair:
+            "Use Repair Search in the window header."
+        case .ready, .dirty:
+            ""
+        }
+    }
+}

--- a/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
+++ b/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
@@ -532,10 +532,9 @@ struct OpenCodeSessionWindowView: View {
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay(
             RoundedRectangle(cornerRadius: 6)
-                .stroke(highlightedTurnID == message.id ? Color.accentColor.opacity(isHighlightPulsing ? 0.95 : 0.25) : Color.clear, lineWidth: 2.5)
-                .scaleEffect(highlightedTurnID == message.id && isHighlightPulsing ? 1.012 : 1.0)
-                .shadow(color: highlightedTurnID == message.id ? Color.accentColor.opacity(isHighlightPulsing ? 0.42 : 0.08) : Color.clear, radius: 8)
-                .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: isHighlightPulsing)
+                .stroke(highlightedTurnID == message.id ? Color.accentColor.opacity(isHighlightPulsing ? 0.34 : 0.18) : Color.clear, lineWidth: 1)
+                .shadow(color: highlightedTurnID == message.id ? Color.accentColor.opacity(isHighlightPulsing ? 0.12 : 0.04) : Color.clear, radius: 3)
+                .animation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true), value: isHighlightPulsing)
         )
     }
 
@@ -1155,10 +1154,8 @@ extension OpenCodeSessionWindowView {
         }
 
         Task {
-            try? await Task.sleep(for: .seconds(3.5))
+            try? await Task.sleep(for: .seconds(4.5))
             if highlightedTurnID == result.turnSourceID {
-                highlightedTurnID = nil
-                highlightedSearchQuery = ""
                 isHighlightPulsing = false
             }
         }

--- a/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
+++ b/Vapor/Vapor/Views/OpenCodeSessionWindowView.swift
@@ -91,8 +91,7 @@ struct OpenCodeSessionWindowView: View {
         isLoadingSession = true
         Task.detached { [sourceID] in
             let reader = OpenCodeReader.shared
-            let fetchedSessions = reader.fetchSessions(limit: 1)
-            let session = fetchedSessions.first { $0.id == sourceID }
+            let session = reader.fetchSession(sessionID: sourceID)
             let fetchedMessages = reader.fetchAllMessages(sessionID: sourceID)
             let cost = fetchedMessages.compactMap(\.cost).reduce(0, +)
 

--- a/Vapor/Vapor/Views/SettingsView.swift
+++ b/Vapor/Vapor/Views/SettingsView.swift
@@ -299,6 +299,25 @@ struct SettingsView: View {
                     }
                     .padding(8)
                 }
+
+                GroupBox("Agent Sessions") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Picker("Refresh session list", selection: Binding(
+                            get: { preferences.agentSessionRefreshInterval },
+                            set: { preferences.agentSessionRefreshInterval = $0 }
+                        )) {
+                            ForEach(AgentSessionRefreshInterval.allCases, id: \.self) { interval in
+                                Text(interval.displayName).tag(interval)
+                            }
+                        }
+                        .pickerStyle(.menu)
+
+                        Text("How often Vapor checks OpenCode for new or updated sessions while the Sessions section is open. Manual refresh is always available in the sidebar.")
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(8)
+                }
             }
             .padding(20)
         }

--- a/Vapor/VaporTests/OpenCodeVectorSearchTests.swift
+++ b/Vapor/VaporTests/OpenCodeVectorSearchTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+import SQLiteVec
+@testable import Vapor
+
+final class OpenCodeVectorSearchTests: XCTestCase {
+
+    func testTextChunkerCreatesLargerOverlappingChunks() {
+        let paragraph = "authentication token refresh search indexing vector database result context "
+        let text = String(repeating: paragraph, count: 80)
+
+        let chunks = TextChunker.chunk(text)
+
+        XCTAssertGreaterThan(chunks.count, 1)
+        XCTAssertTrue(chunks.allSatisfy { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+        XCTAssertLessThanOrEqual(chunks[0].count, TextChunker.chunkSize)
+        XCTAssertGreaterThan(chunks[1].count, TextChunker.overlap)
+        XCTAssertTrue(chunks[1].contains("authentication") || chunks[1].contains("token"))
+    }
+
+    func testTurnVectorStoreSearchFindsSessionScopedRelevantChunk() async throws {
+        try SQLiteVec.initialize()
+        let database = try Database(.inMemory)
+        let store = TurnVectorStore(
+            database: database,
+            turnTableName: "test_turn_vectors",
+            chunksTableName: "test_turn_chunks",
+            dimensions: 4,
+            embed: Self.fakeEmbedding(for:)
+        )
+        try await TurnVectorStore.initializeSchema(
+            database: database,
+            turnTableName: "test_turn_vectors",
+            chunksTableName: "test_turn_chunks",
+            dimensions: 4
+        )
+
+        let chunks = [
+            TurnVectorChunk(
+                embeddingID: "turn:session-a:turn-auth:0",
+                text: "Implemented authentication token refresh and bearer token validation for the local API search endpoint.",
+                turnSourceID: "turn-auth",
+                sessionID: "session-a",
+                chunkIndex: 0
+            ),
+            TurnVectorChunk(
+                embeddingID: "turn:session-b:turn-quaker:0",
+                text: "Discussed Quaker meeting notes, archival documents, and unrelated historical records.",
+                turnSourceID: "turn-quaker",
+                sessionID: "session-b",
+                chunkIndex: 0
+            )
+        ]
+
+        let storedCount = try await store.embedAndStore(chunks)
+        let sessionChunkCount = await store.turnChunkCount(sessionID: "session-a")
+        let sessionVectorCount = await store.turnVectorCount(sessionID: "session-a")
+        XCTAssertEqual(storedCount, 2)
+        XCTAssertEqual(sessionChunkCount, 1)
+        XCTAssertEqual(sessionVectorCount, 1)
+
+        let results = try await store.search(matching: "auth token", sessionID: "session-a", limit: 5)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.sessionID, "session-a")
+        XCTAssertEqual(results.first?.turnSourceID, "turn-auth")
+        XCTAssertTrue(results.first?.chunkText.localizedCaseInsensitiveContains("authentication token") == true)
+    }
+
+    func testTurnVectorStoreUpsertDoesNotDuplicateMetadataRows() async throws {
+        try SQLiteVec.initialize()
+        let database = try Database(.inMemory)
+        let store = TurnVectorStore(
+            database: database,
+            turnTableName: "test_turn_vectors_upsert",
+            chunksTableName: "test_turn_chunks_upsert",
+            dimensions: 4,
+            embed: Self.fakeEmbedding(for:)
+        )
+        try await TurnVectorStore.initializeSchema(
+            database: database,
+            turnTableName: "test_turn_vectors_upsert",
+            chunksTableName: "test_turn_chunks_upsert",
+            dimensions: 4
+        )
+
+        let chunk = TurnVectorChunk(
+            embeddingID: "turn:session-a:turn-auth:0",
+            text: "Authentication token validation context should replace itself when indexed again.",
+            turnSourceID: "turn-auth",
+            sessionID: "session-a",
+            chunkIndex: 0
+        )
+
+        _ = try await store.embedAndStore([chunk])
+        _ = try await store.embedAndStore([chunk])
+        let sessionChunkCount = await store.turnChunkCount(sessionID: "session-a")
+        let sessionVectorCount = await store.turnVectorCount(sessionID: "session-a")
+        let hasVectors = await store.hasTurnVectors(turnSourceID: "turn-auth")
+
+        XCTAssertEqual(sessionChunkCount, 1)
+        XCTAssertEqual(sessionVectorCount, 1)
+        XCTAssertTrue(hasVectors)
+    }
+
+    func testRealMiniLMFindsDictationCloudFallbackPhrase() async throws {
+        try SQLiteVec.initialize()
+        let embeddingService = MiniLMEmbeddingService()
+        try await embeddingService.initialize()
+
+        let database = try Database(.inMemory)
+        let store = TurnVectorStore(
+            database: database,
+            turnTableName: "test_minilm_turn_vectors",
+            chunksTableName: "test_minilm_turn_chunks",
+            dimensions: MiniLMEmbeddingService.dimensions,
+            embed: { text in try await embeddingService.embed(text: text) }
+        )
+        try await TurnVectorStore.initializeSchema(
+            database: database,
+            turnTableName: "test_minilm_turn_vectors",
+            chunksTableName: "test_minilm_turn_chunks",
+            dimensions: MiniLMEmbeddingService.dimensions
+        )
+
+        let chunks = [
+            TurnVectorChunk(
+                embeddingID: "turn:session-a:turn-dictation:0",
+                text: "Dictation no longer requires on-device recognition and can use cloud fallback. The settings UI reports recognizer availability and current route as Automatic.",
+                turnSourceID: "turn-dictation",
+                sessionID: "session-a",
+                chunkIndex: 0
+            ),
+            TurnVectorChunk(
+                embeddingID: "turn:session-a:turn-build:0",
+                text: "Let me do a quick build check to catch compiler issues before continuing with the implementation.",
+                turnSourceID: "turn-build",
+                sessionID: "session-a",
+                chunkIndex: 0
+            ),
+            TurnVectorChunk(
+                embeddingID: "turn:session-a:turn-commit:0",
+                text: "Do not auto-commit and push. Stage changes only after reviewing the working tree and generated files.",
+                turnSourceID: "turn-commit",
+                sessionID: "session-a",
+                chunkIndex: 0
+            )
+        ]
+
+        _ = try await store.embedAndStore(chunks)
+
+        let results = try await store.search(
+            matching: "dictation on local device vs cloud based",
+            sessionID: "session-a",
+            limit: 3
+        )
+
+        XCTAssertFalse(results.isEmpty)
+        let rankedTurnIDs = results.map(\.turnSourceID)
+        XCTAssertTrue(
+            rankedTurnIDs.prefix(3).contains("turn-dictation"),
+            "Expected dictation chunk in top 3, got: \(rankedTurnIDs)"
+        )
+    }
+
+    private static func fakeEmbedding(for text: String) async throws -> [Float] {
+        let lowercased = text.lowercased()
+        if lowercased.contains("auth") || lowercased.contains("token") || lowercased.contains("bearer") {
+            return [1, 0, 0, 0]
+        }
+        if lowercased.contains("quaker") || lowercased.contains("archive") || lowercased.contains("historical") {
+            return [0, 1, 0, 0]
+        }
+        return [0, 0, 1, 0]
+    }
+}

--- a/Vapor/VaporTests/OpenCodeVectorSearchTests.swift
+++ b/Vapor/VaporTests/OpenCodeVectorSearchTests.swift
@@ -102,6 +102,50 @@ final class OpenCodeVectorSearchTests: XCTestCase {
         XCTAssertTrue(hasVectors)
     }
 
+    func testTurnVectorStoreSearchScopesBeforeRanking() async throws {
+        try SQLiteVec.initialize()
+        let database = try Database(.inMemory)
+        let store = TurnVectorStore(
+            database: database,
+            turnTableName: "test_turn_vectors_scope",
+            chunksTableName: "test_turn_chunks_scope",
+            dimensions: 4,
+            embed: Self.fakeEmbedding(for:)
+        )
+        try await TurnVectorStore.initializeSchema(
+            database: database,
+            turnTableName: "test_turn_vectors_scope",
+            chunksTableName: "test_turn_chunks_scope",
+            dimensions: 4
+        )
+
+        var chunks: [TurnVectorChunk] = [
+            TurnVectorChunk(
+                embeddingID: "turn:session-a:turn-quaker:0",
+                text: "Discussed Quaker archive notes and historical records.",
+                turnSourceID: "turn-quaker",
+                sessionID: "session-a",
+                chunkIndex: 0
+            )
+        ]
+        for index in 0..<20 {
+            chunks.append(TurnVectorChunk(
+                embeddingID: "turn:session-b:turn-auth-\(index):0",
+                text: "Authentication bearer token refresh implementation details.",
+                turnSourceID: "turn-auth-\(index)",
+                sessionID: "session-b",
+                chunkIndex: 0
+            ))
+        }
+        _ = try await store.embedAndStore(chunks)
+
+        let results = try await store.search(matching: "authentication token", sessionID: "session-a", limit: 1)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.sessionID, "session-a")
+        XCTAssertEqual(results.first?.turnSourceID, "turn-quaker")
+    }
+
     func testRealMiniLMFindsDictationCloudFallbackPhrase() async throws {
         try SQLiteVec.initialize()
         let embeddingService = MiniLMEmbeddingService()

--- a/docs/agent-memory-api.md
+++ b/docs/agent-memory-api.md
@@ -1,0 +1,267 @@
+# Agent Memory API
+
+Vapor can index local agent sessions and expose them through a local authenticated HTTP API. Agents can use this API to search prior conversation history, implementation decisions, errors, and tool results from the current indexed session.
+
+The API is local-first:
+
+- Server: `http://127.0.0.1:8766`
+- Auth: Bearer token via `VAPOR_API_TOKEN`
+- Current source: OpenCode sessions from `~/.local/share/opencode/opencode.db`
+- Vector store: `~/Library/Application Support/Vapor/vectors.db`
+- Embedding model: MiniLM `all-MiniLM-L6-v2`
+
+## User Workflow
+
+1. Open Vapor.
+2. Open the Context Tray and expand **Sessions**.
+3. Open an agent session.
+4. Use the session header action when needed:
+   - **Import & Index** for a session that has not been indexed.
+   - **Update Search** for a session with a usable but stale or partial index.
+   - **Repair Search** for a session with imported data but no usable search vectors.
+5. Agents can query the API once `can_search` is `true`.
+
+## Search Index Statuses
+
+| Status | Can Search | Meaning | User Action |
+| --- | ---: | --- | --- |
+| `ready` | Yes | Chunks and vectors are present and current. | None |
+| `dirty` | Yes | Session has newer data than the last import. | Click **Update Search** for best recall. |
+| `partial` | Yes | Some vectors are missing, but enough exist to search. | Search works; click **Update Search** if recall matters. |
+| `repair_needed` | No | Imported content exists but no usable search vectors are available. | Click **Repair Search**. |
+| `missing` | No | Session is not imported. | Click **Import & Index**. |
+| `indexing` | Soon | Importing or indexing is in progress. | Wait and retry shortly. |
+
+Agents should check index status before searching. If `can_search` is false, the agent should report the provided `message` to the user instead of claiming no results were found.
+
+## Authentication
+
+All API requests require a bearer token:
+
+```bash
+TOKEN="$VAPOR_API_TOKEN"
+BASE="${VAPOR_API_URL:-http://127.0.0.1:8766}"
+```
+
+Vapor sets `VAPOR_API_TOKEN` for child processes it launches. If an agent is launched outside Vapor's environment, the user must provide or export the token.
+
+## Endpoints
+
+### Current Session
+
+```http
+GET /api/agent/current-session
+```
+
+Optional query parameters:
+
+- `cwd`: current working directory used to infer the session.
+- `source`: source adapter, currently `opencode`.
+
+Example:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/current-session?cwd=$(python3 -c 'import os,urllib.parse; print(urllib.parse.quote(os.getcwd()))')" \
+  | python3 -m json.tool
+```
+
+Response shape:
+
+```json
+{
+  "source": "opencode",
+  "session_id": "ses_...",
+  "title": "Staging tested changes for commit",
+  "directory": "/Users/ddahl/code/memetic-research-labs-llc/vapor",
+  "updated_at": "2026-05-06T12:34:56Z",
+  "message_count": 2903,
+  "index_status": {
+    "status": "partial",
+    "can_search": true,
+    "needs_update": true,
+    "needs_repair": false,
+    "chunks": 3042,
+    "vectors": 2181,
+    "coverage": 0.717,
+    "model": "MiniLM all-MiniLM-L6-v2",
+    "message": "Search is usable but incomplete. Ask the user to click Update Search if recall matters."
+  }
+}
+```
+
+### Index Status
+
+```http
+GET /api/agent/index/status
+```
+
+Optional query parameters:
+
+- `session_id`: explicit session ID.
+- `cwd`: infer the session from a working directory.
+- `source`: source adapter, currently `opencode`.
+
+Example:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/index/status?session_id=ses_abc123" \
+  | python3 -m json.tool
+```
+
+Important fields:
+
+- `can_search`: whether agents can use search now.
+- `needs_update`: search is usable but stale or incomplete.
+- `needs_repair`: search is unavailable until repaired.
+- `chunks`: indexed metadata chunks.
+- `vectors`: searchable vectors available.
+- `coverage`: `vectors / chunks`.
+- `message`: user-facing guidance.
+
+### Search Agent Memory
+
+```http
+GET /api/agent/search
+```
+
+Query parameters:
+
+- `q`: required search query.
+- `session_id`: optional explicit session ID.
+- `limit`: optional result limit, default `20`.
+
+Example with inferred session:
+
+```bash
+QUERY="why did sqlite vec search fail"
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/search?q=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))' "$QUERY")&limit=10" \
+  | python3 -m json.tool
+```
+
+Explicit session route:
+
+```http
+GET /api/agent/sessions/{session_id}/search
+```
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/sessions/ses_abc123/search?q=sqlite%20vec%20filtering&limit=10" \
+  | python3 -m json.tool
+```
+
+Response shape:
+
+```json
+{
+  "results": [
+    {
+      "embedding_id": "turn:ses_...:msg_...:0",
+      "distance": 0.211,
+      "chunk_text": "Relevant indexed text...",
+      "turn_source_id": "msg_...",
+      "session_id": "ses_...",
+      "chunk_index": 0
+    }
+  ],
+  "count": 1
+}
+```
+
+The score is **cosine distance**. Lower is better.
+
+- `0.0` is closest.
+- `< 0.30` is usually a strong match.
+- `< 0.60` is usually related.
+- Higher values are weaker.
+
+### Expand Context
+
+```http
+GET /api/agent/sessions/{session_id}/context
+```
+
+Query parameters:
+
+- `q`: required query used to find relevant context.
+- `context_turns`: optional surrounding turn count, default `2`.
+
+Example:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/agent/sessions/ses_abc123/context?q=sqlite%20vec%20filtering&context_turns=2" \
+  | python3 -m json.tool
+```
+
+Agents should expand context before relying on a search result for a detailed answer.
+
+## Agent Workflow
+
+Recommended agent behavior:
+
+1. Call `/api/agent/current-session?cwd=...`.
+2. Read `index_status`.
+3. If `can_search` is false, report `message` to the user and stop.
+4. If `can_search` is true, call `/api/agent/search` or `/api/agent/sessions/{id}/search`.
+5. Use `/api/agent/sessions/{id}/context` before relying on a result.
+
+Example decision mapping:
+
+- `missing`: ask the user to click **Import & Index**.
+- `repair_needed`: ask the user to click **Repair Search**.
+- `partial`: search is usable, but mention that **Update Search** improves recall.
+- `dirty`: search is usable, but **Update Search** will include newer data.
+- `ready`: search normally.
+
+## Skill Installation
+
+Install the local agent skill files with:
+
+```bash
+scripts/install-vapor-skill.sh
+```
+
+This installs:
+
+- `~/.opencode/skills/vapor-agent-memory`
+- `~/.claude/skills/vapor-agent-memory`
+
+## Privacy and Storage
+
+- API is bound to localhost.
+- Bearer token authentication is required.
+- OpenCode data is read from the local OpenCode SQLite database.
+- Embeddings are generated locally using MiniLM `all-MiniLM-L6-v2`.
+- Vectors are stored locally in `~/Library/Application Support/Vapor/vectors.db`.
+
+## Troubleshooting
+
+### `401 Unauthorized`
+
+The token is missing or incorrect. Ensure `VAPOR_API_TOKEN` is set and passed as a bearer token.
+
+### `missing`
+
+The session has not been imported. Open the session in Vapor and click **Import & Index**.
+
+### `repair_needed`
+
+Imported content exists, but no usable vectors are available. Click **Repair Search** in Vapor.
+
+### `partial`
+
+Search is usable, but some vectors are missing. Click **Update Search** for better recall.
+
+### No current session
+
+Pass an explicit `session_id`, or call the endpoint with a `cwd` that maps to a known OpenCode session.
+
+## Limitations
+
+- OpenCode is the first supported source.
+- Broader trace segmentation for reasoning, tool inputs, tool outputs, patch summaries, and step summaries is planned.
+- A dedicated `vapor-memory` CLI wrapper is planned; HTTP is the canonical API.

--- a/docs/test-plan-2026-05-04.md
+++ b/docs/test-plan-2026-05-04.md
@@ -1,0 +1,73 @@
+Test Plan — AI Session Capture
+Phase A: Settings & Onboarding
+1. Open Settings (cmd+,)
+2. Session Capture tab — verify it appears with the camera icon
+3. Toggle "Enable session capture" ON — the onboarding sheet should appear (not enable immediately)
+   - Verify: icon, title, 4 feature bullets, privacy note, "Not Now" and "Enable Capture" buttons
+   - Click "Not Now" — sheet dismisses, toggle stays OFF
+   - Toggle ON again — this time onboarding should NOT appear (already seen), toggle should enable directly
+4. Idle timeout slider — drag it, verify it saves
+5. Screenshot link window slider — drag it
+6. OpenCode log path — leave blank (auto-detect) or point it at your OpenCode log dir
+7. Projects tab — verify it appears with folder icon
+   - Click Create, type a name, click Create — project should appear in the list
+   - Click the pencil icon — edit sheet opens, rename, save
+   - Click the trash icon — project deleted
+   - Create a project for this repo (e.g. "vapor")
+8. Export & Redaction tab — verify toggles and denylist editor
+   - Type a regex pattern (e.g. sk-ant-\w+), click "Save Denylist"
+Phase B: Menu Bar Capture Controls
+9. Click the Vapor menu bar icon
+   - With capture enabled: verify green dot + "Capturing" text
+   - Pause Capture — verify orange dot + "Capture Paused"
+   - Resume Capture — verify green dot returns
+   - Stop Capture — verify dot disappears, only Show/Settings/Quit remain
+Phase C: OpenCode Adapter (Live Capture)
+10. With capture enabled and resumed, use OpenCode in a terminal — have a short conversation
+11. Back in Vapor, check status bar / log for capture activity
+12. Sidebar → "AI Sessions" — click it
+    - Session list should show your OpenCode session with title, tool badge (terminal icon), turn count, date, tags
+13. Click the session — SessionReaderView opens
+    - Verify: title, tool badge, metadata row, turn cards with role badges
+    - Click ellipsis (...) on a turn → "Copy text" (verify clipboard), "Mark private"
+Phase D: Session Reader Features
+14. Tags — verify capsule chips if LLM tags were extracted
+15. Summary — verify summary card if generated
+16. Export button (square+arrow icon) — click it
+Phase E: Export & Redaction
+17. Export Preview Sheet:
+    - Loading spinner while preview calculates
+    - Verify: title, tool badge, turn count, file list
+    - If redaction patterns matched: orange "Redactions" warning with count
+    - If sensitive keywords detected: red warning box
+    - If no project path: yellow "No Project Path" warning
+    - Enter a project root path (e.g. this repo)
+    - Click Export → green "Export completed" confirmation
+18. Check the git repo — .vapor-context/ directory should exist with:
+    - sessions/<date>/<sessionId>/transcript.md
+    - sessions/<date>/<sessionId>/meta.json
+    - sessions/<date>/<sessionId>/entities.json
+    - Symlink in .vapor-context/sessions/<branch>/ pointing to date dir
+Phase F: Semantic Search Integration
+19. In Context Explorer, search bar at top — type a query related to your OpenCode conversation
+    - Results should show two sections: context items AND "AI Session Turns"
+    - Click an AI turn result → navigates to parent session reader
+Phase G: Project Filtering
+20. Select the "vapor" project in the sidebar
+    - AI Sessions badge should show project-scoped count
+    - Session list scoped to that project only
+Phase H: HTTP API Smoke Test
+# List sessions
+curl -s http://localhost:8766/api/sessions | python3 -m json.tool
+# List projects
+curl -s http://localhost:8766/api/projects | python3 -m json.tool
+# Search
+curl -s -X POST http://localhost:8766/api/search/sessions \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"test","limit":5}' | python3 -m json.tool
+# Export config
+curl -s http://localhost:8766/api/export/config | python3 -m json.tool
+Watch For
+- Crashes on first launch — SwiftData migration for new models (AISession, AITurn, VaporProject)
+- Empty states — graceful messages when no sessions/projects exist
+- Xcode console — SwiftData schema migration errors, SQLite-vec issues, adapter file-watcher errors

--- a/scripts/install-vapor-skill.sh
+++ b/scripts/install-vapor-skill.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-OPENCODE_SKILL_DIR="$HOME/.opencode/skills/vapor-session-search"
-CLAUDE_SKILL_DIR="$HOME/.claude/skills/vapor-session-search"
-SOURCE_SKILL_DIR="$REPO_ROOT/.opencode/skills/vapor-session-search"
+OPENCODE_SKILL_DIR="$HOME/.opencode/skills/vapor-agent-memory"
+CLAUDE_SKILL_DIR="$HOME/.claude/skills/vapor-agent-memory"
+SOURCE_SKILL_DIR="$REPO_ROOT/.opencode/skills/vapor-agent-memory"
 
 install_skill() {
     local target_dir="$1"

--- a/scripts/install-vapor-skill.sh
+++ b/scripts/install-vapor-skill.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+OPENCODE_SKILL_DIR="$HOME/.opencode/skills/vapor-session-search"
+CLAUDE_SKILL_DIR="$HOME/.claude/skills/vapor-session-search"
+SOURCE_SKILL_DIR="$REPO_ROOT/.opencode/skills/vapor-session-search"
+
+install_skill() {
+    local target_dir="$1"
+    local label="$2"
+
+    if [ -d "$target_dir" ]; then
+        echo "$label skill already exists at $target_dir (skipping)"
+    else
+        mkdir -p "$target_dir"
+        cp "$SOURCE_SKILL_DIR/SKILL.md" "$target_dir/SKILL.md"
+        echo "Installed $label skill to $target_dir"
+    fi
+}
+
+if [ ! -f "$SOURCE_SKILL_DIR/SKILL.md" ]; then
+    echo "Error: Source skill not found at $SOURCE_SKILL_DIR/SKILL.md" >&2
+    exit 1
+fi
+
+install_skill "$OPENCODE_SKILL_DIR" "OpenCode"
+install_skill "$CLAUDE_SKILL_DIR" "Claude Code"
+
+echo ""
+echo "Done. Both skills are now available to agents launched from this machine."
+echo "Ensure Vapor is running and the session has been indexed before searching."


### PR DESCRIPTION
## Summary
- Adds live OpenCode session browsing with per-session Import/Update/Repair Search indexing.
- Adds SwiftData session/turn/content models plus a session detail window with search overlay and result highlighting.
- Adds a regenerated all-MiniLM-L6-v2 CoreML embedding model, dedicated turn vector store, and regression tests for semantic session search.
- Adds local agent skill docs and installer for Vapor session search API usage.

## Verification
- `xcodebuild -project Vapor/Vapor.xcodeproj -derivedDataPath .build/DerivedData test -scheme Vapor -configuration Debug -destination 'platform=macOS' -skip-testing:VaporUITests`
- `make lint`